### PR TITLE
Add flang makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ mom6_standalone.e*
 ocean.stats*
 ocean_solo.res
 time_stamp.out
+
+__pycache__/
+*.pyc
+.ipynb_checkpoints/

--- a/build-utils/makefile-templates/ncar-flang.mk
+++ b/build-utils/makefile-templates/ncar-flang.mk
@@ -1,0 +1,139 @@
+# Template for the PGI Compilers
+
+############
+# commands #
+############
+
+FC = mpif90
+CC = mpicc
+CXX = mpicxx
+LD = mpif90 $(MAIN_PROGRAM)
+
+############
+#  flags   #
+############
+
+DEBUG =
+MAKEFLAGS += --jobs=8
+LDFLAGS :=
+
+FC_AUTO_R8 = -fdefault-real-8 -fdefault-double-8
+FPPFLAGS :=
+FFLAGS = $(FC_AUTO_R8)  -fconvert=big-endian
+FFLAGS_DEBUG = -O0 -g
+FFLAGS_REPRO = -O2
+
+CFLAGS = -std=gnu99
+CFLAGS_REPRO = -O2
+CFLAGS_DEBUG =
+CPPFLAGS := $(shell pkg-config --cflags yaml-0.1)
+
+# Get compile flags based on target macros.
+ifeq ($(DEBUG),1)
+  FFLAGS += $(FFLAGS_DEBUG)
+  CFLAGS += $(CFLAGS_DEBUG)
+else
+  FFLAGS += $(FFLAGS_REPRO)
+  CFLAGS += $(CFLAGS_REPRO)
+endif
+
+# NetCDF Flags
+FFLAGS += $(shell nf-config --fflags)
+CFLAGS += $(shell nc-config --cflags)
+
+ifneq ($(findstring -Duse_netCDF,$(CPPDEFS)),)
+  # add the use_LARGEFILE cppdef
+  CPPDEFS += -Duse_LARGEFILE
+endif
+
+# Linking Flags
+LDFLAGS += $(shell nc-config --libs) $(shell nf-config --flibs) -Wl,--allow-multiple-definition
+
+#---------------------------------------------------------------------------
+# you should never need to change any lines below.
+
+# see the MIPSPro F90 manual for more details on some of the file extensions
+# discussed here.
+# this makefile template recognizes fortran sourcefiles with extensions
+# .f, .f90, .F, .F90. Given a sourcefile <file>.<ext>, where <ext> is one of
+# the above, this provides a number of default actions:
+
+# make <file>.opt	create an optimization report
+# make <file>.o		create an object file
+# make <file>.s		create an assembly listing
+# make <file>.x		create an executable file, assuming standalone
+#			source
+# make <file>.i		create a preprocessed file (for .F)
+# make <file>.i90	create a preprocessed file (for .F90)
+
+# The macro TMPFILES is provided to slate files like the above for removal.
+
+RM = rm -f
+TMPFILES = .*.m *.B *.L *.i *.i90 *.l *.s *.mod *.opt
+
+.SUFFIXES: .F .F90 .H .L .T .f .f90 .h .i .i90 .l .o .s .opt .x
+
+.f.L:
+	$(FC) $(FFLAGS) -c -listing $*.f
+.f.opt:
+	$(FC) $(FFLAGS) -c -opt_report_level max -opt_report_phase all -opt_report_file $*.opt $*.f
+.f.l:
+	$(FC) $(FFLAGS) -c $(LIST) $*.f
+.f.T:
+	$(FC) $(FFLAGS) -c -cif $*.f
+.f.o:
+	$(FC) $(FFLAGS) -c $*.f
+.f.s:
+	$(FC) $(FFLAGS) -S $*.f
+.f.x:
+	$(FC) $(FFLAGS) -o $*.x $*.f *.o $(LDFLAGS)
+.f90.L:
+	$(FC) $(FFLAGS) -c -listing $*.f90
+.f90.opt:
+	$(FC) $(FFLAGS) -c -opt_report_level max -opt_report_phase all -opt_report_file $*.opt $*.f90
+.f90.l:
+	$(FC) $(FFLAGS) -c $(LIST) $*.f90
+.f90.T:
+	$(FC) $(FFLAGS) -c -cif $*.f90
+.f90.o:
+	$(FC) $(FFLAGS) -c $*.f90
+.f90.s:
+	$(FC) $(FFLAGS) -c -S $*.f90
+.f90.x:
+	$(FC) $(FFLAGS) -o $*.x $*.f90 *.o $(LDFLAGS)
+.F.L:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -listing $*.F
+.F.opt:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -opt_report_level max -opt_report_phase all -opt_report_file $*.opt $*.F
+.F.l:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c $(LIST) $*.F
+.F.T:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -cif $*.F
+.F.f:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) -EP $*.F > $*.f
+.F.i:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) -P $*.F
+.F.o:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c $*.F
+.F.s:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -S $*.F
+.F.x:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -o $*.x $*.F *.o $(LDFLAGS)
+.F90.L:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -listing $*.F90
+.F90.opt:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -opt_report_level max -opt_report_phase all -opt_report_file $*.opt $*.F90
+.F90.l:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c $(LIST) $*.F90
+.F90.T:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -cif $*.F90
+.F90.f90:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) -EP $*.F90 > $*.f90
+.F90.i90:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) -P $*.F90
+.F90.o:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c $*.F90
+.F90.s:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -S $*.F90
+.F90.x:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -o $*.x $*.F90 *.o $(LDFLAGS)

--- a/build-utils/makefile-templates/ncar-flang_ptree.mk
+++ b/build-utils/makefile-templates/ncar-flang_ptree.mk
@@ -1,0 +1,116 @@
+# Template for the PGI Compilers
+
+############
+# commands #
+############
+
+FC = flang
+CC = mpicc
+CXX = mpicxx
+LD = echo flang # no linking, just parsing
+AR = echo ar rv # no archiving, just parsing
+
+############
+#  flags   #
+############
+
+DEBUG =
+MAKEFLAGS += --jobs=8
+LDFLAGS :=
+
+FPPFLAGS :=
+FFLAGS = -fc1 -fdebug-dump-parse-tree-no-sema -Duse_libMPI -Duse_netCDF -DSPMD
+CFLAGS = -Xclang -ast-dump -fsyntax-only -Duse_libMPI -Duse_netCDF -DSPMD
+
+# NetCDF Flags
+FFLAGS += $(shell nf-config --fflags)
+CFLAGS += $(shell nc-config --cflags)
+
+#---------------------------------------------------------------------------
+# you should never need to change any lines below.
+
+# see the MIPSPro F90 manual for more details on some of the file extensions
+# discussed here.
+# this makefile template recognizes fortran sourcefiles with extensions
+# .f, .f90, .F, .F90. Given a sourcefile <file>.<ext>, where <ext> is one of
+# the above, this provides a number of default actions:
+
+# make <file>.opt	create an optimization report
+# make <file>.o		create an object file
+# make <file>.s		create an assembly listing
+# make <file>.x		create an executable file, assuming standalone
+#			source
+# make <file>.i		create a preprocessed file (for .F)
+# make <file>.i90	create a preprocessed file (for .F90)
+
+# The macro TMPFILES is provided to slate files like the above for removal.
+
+RM = rm -f
+TMPFILES = .*.m *.B *.L *.i *.i90 *.l *.s *.mod *.opt
+
+.SUFFIXES: .F .F90 .H .L .T .f .f90 .h .i .i90 .l .o .s .opt .x
+
+.f.L:
+	$(FC) $(FFLAGS) -c -listing $*.f
+.f.opt:
+	$(FC) $(FFLAGS) -c -opt_report_level max -opt_report_phase all -opt_report_file $*.opt $*.f
+.f.l:
+	$(FC) $(FFLAGS) -c $(LIST) $*.f
+.f.T:
+	$(FC) $(FFLAGS) -c -cif $*.f
+.f.o:
+	$(FC) $(FFLAGS) -c $*.f
+.f.s:
+	$(FC) $(FFLAGS) -S $*.f
+.f.x:
+	$(FC) $(FFLAGS) -o $*.x $*.f *.o $(LDFLAGS)
+.f90.L:
+	$(FC) $(FFLAGS) -c -listing $*.f90
+.f90.opt:
+	$(FC) $(FFLAGS) -c -opt_report_level max -opt_report_phase all -opt_report_file $*.opt $*.f90
+.f90.l:
+	$(FC) $(FFLAGS) -c $(LIST) $*.f90
+.f90.T:
+	$(FC) $(FFLAGS) -c -cif $*.f90
+.f90.o:
+	$(FC) $(FFLAGS) -c $*.f90
+.f90.s:
+	$(FC) $(FFLAGS) -c -S $*.f90
+.f90.x:
+	$(FC) $(FFLAGS) -o $*.x $*.f90 *.o $(LDFLAGS)
+.F.L:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -listing $*.F
+.F.opt:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -opt_report_level max -opt_report_phase all -opt_report_file $*.opt $*.F
+.F.l:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c $(LIST) $*.F
+.F.T:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -cif $*.F
+.F.f:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) -EP $*.F > $*.f
+.F.i:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) -P $*.F
+.F.o:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c $*.F
+.F.s:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -S $*.F
+.F.x:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -o $*.x $*.F *.o $(LDFLAGS)
+.F90.L:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -listing $*.F90
+.F90.opt:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -opt_report_level max -opt_report_phase all -opt_report_file $*.opt $*.F90
+.F90.l:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c $(LIST) $*.F90
+.F90.T:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -cif $*.F90
+.F90.f90:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) -EP $*.F90 > $*.f90
+.F90.i90:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) -P $*.F90
+.F90.o:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c $*.F90
+.F90.s:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -S $*.F90
+.F90.x:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -o $*.x $*.F90 *.o $(LDFLAGS)

--- a/build-utils/mkmf/mkmf
+++ b/build-utils/mkmf/mkmf
@@ -30,7 +30,7 @@ use strict;
 use File::Basename;
 use Getopt::Long qw(:config posix_default bundling no_ignore_case);
 use Config;                     # use to put in platform-specific stuff
-use vars qw( $opt_a $opt_b $opt_c $opt_d $opt_f $opt_g $opt_I $opt_l $opt_m $opt_o $opt_p $opt_t $opt_v $opt_x $opt_use_cpp); # declare these global to be shared with Getopt:Std
+use vars qw( $opt_a $opt_b $opt_c $opt_d $opt_f $opt_g $opt_I $opt_l $opt_m $opt_o $opt_p $opt_t $opt_v $opt_x $opt_use_cpp $opt_gen_ptree); # declare these global to be shared with Getopt:Std
 
 #subroutines
 sub ensureTrailingSlash {
@@ -56,6 +56,7 @@ GetOptions("abspath|a=s" => \$opt_a,
            "verbose|v" => \$opt_v,
            "execute|x" => \$opt_x,
            "use-cpp" => \$opt_use_cpp,
+           "gen-ptree" => \$opt_gen_ptree,
           ) or die "\aSyntax: $0 [-a abspath] [-b blddir] [-c cppdefs] [-d] [-f] [-g] [-I includes] [-m makefile] [-o otherflags] [-l linkflags] [-p program] [-t template] [-v] [-x] [--use-cpp] [targets]\n";
 $opt_v = 1 if $opt_d;   # debug flag turns on verbose flag also
 print "$0 $version\n" if $opt_v;
@@ -81,22 +82,43 @@ my @inc_suffixes = ( q/\.H/, q/\.fh/, q/\.h/, q/\.inc/, q/\.h90/ );
 # suffixes for the target (mkmf -p): if isn't on the list below it's a program
 my @tgt_suffixes = ( q/\.a/ );
 
-my %compile_cmd = ( # commands to create .o file from a given source file suffix
-      # Fix formed Fortran files
-      q/.F/   => q/$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) $(OTHERFLAGS) $(OTHER_FFLAGS) -c/,
-      q/.f/   => q/$(FC) $(FPPFLAGS) $(FFLAGS) $(OTHERFLAGS) $(OTHER_FFLAGS) -c/,
-      # Free formed Fortran files
-      q/.F90/ => q/$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) $(OTHERFLAGS) $(OTHER_FFLAGS) -c/,
-      q/.f90/ => q/$(FC) $(FPPFLAGS) $(FFLAGS) $(OTHERFLAGS) $(OTHER_FFLAGS) -c/,
-      # C files
-      q/.c/   => q/$(CC) $(CPPDEFS) $(CPPFLAGS) $(CFLAGS) $(OTHERFLAGS) $(OTHER_CFLAGS) -c/,
-      # C++ files
-      q/.C/   => q/$(CXX) $(CPPDEFS) $(CPPFLAGS) $(CXXFLAGS) $(OTHERFLAGS) $(OTHER_CXXFLAGS) -c/,
-      q/.cc/  => q/$(CXX) $(CPPDEFS) $(CPPFLAGS) $(CXXFLAGS) $(OTHERFLAGS) $(OTHER_CXXFLAGS) -c/,
-      q/.cpp/ => q/$(CXX) $(CPPDEFS) $(CPPFLAGS) $(CXXFLAGS) $(OTHERFLAGS) $(OTHER_CXXFLAGS) -c/,
-      q/.cxx/ => q/$(CXX) $(CPPDEFS) $(CPPFLAGS) $(CXXFLAGS) $(OTHERFLAGS) $(OTHER_CXXFLAGS) -c/,
-      q/.c++/ => q/$(CXX) $(CPPDEFS) $(CPPFLAGS) $(CXXFLAGS) $(OTHERFLAGS) $(OTHER_CXXFLAGS) -c/,
-      );
+my %compile_cmd;
+if ( $opt_gen_ptree ) {
+   %compile_cmd = ( # commands to create .o file from a given source file suffix
+         # Fix formed Fortran files
+         q/.F/   => q/$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) $(OTHERFLAGS) $(OTHER_FFLAGS) /,
+         q/.f/   => q/$(FC) $(FPPFLAGS) $(FFLAGS) $(OTHERFLAGS) $(OTHER_FFLAGS) /,
+         # Free formed Fortran files
+         q/.F90/ => q/$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) $(OTHERFLAGS) $(OTHER_FFLAGS) /,
+         q/.f90/ => q/$(FC) $(FPPFLAGS) $(FFLAGS) $(OTHERFLAGS) $(OTHER_FFLAGS) /,
+         # C files
+         q/.c/   => q/$(CC) $(CPPDEFS) $(CPPFLAGS) $(CFLAGS) $(OTHERFLAGS) $(OTHER_CFLAGS) /,
+         # C++ files
+         q/.C/   => q/$(CXX) $(CPPDEFS) $(CPPFLAGS) $(CXXFLAGS) $(OTHERFLAGS) $(OTHER_CXXFLAGS) /,
+         q/.cc/  => q/$(CXX) $(CPPDEFS) $(CPPFLAGS) $(CXXFLAGS) $(OTHERFLAGS) $(OTHER_CXXFLAGS) /,
+         q/.cpp/ => q/$(CXX) $(CPPDEFS) $(CPPFLAGS) $(CXXFLAGS) $(OTHERFLAGS) $(OTHER_CXXFLAGS) /,
+         q/.cxx/ => q/$(CXX) $(CPPDEFS) $(CPPFLAGS) $(CXXFLAGS) $(OTHERFLAGS) $(OTHER_CXXFLAGS) /,
+         q/.c++/ => q/$(CXX) $(CPPDEFS) $(CPPFLAGS) $(CXXFLAGS) $(OTHERFLAGS) $(OTHER_CXXFLAGS) /,
+         );
+}
+else{
+   %compile_cmd = ( # commands to create .o file from a given source file suffix
+         # Fix formed Fortran files
+         q/.F/   => q/$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) $(OTHERFLAGS) $(OTHER_FFLAGS) -c/,
+         q/.f/   => q/$(FC) $(FPPFLAGS) $(FFLAGS) $(OTHERFLAGS) $(OTHER_FFLAGS) -c/,
+         # Free formed Fortran files
+         q/.F90/ => q/$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) $(OTHERFLAGS) $(OTHER_FFLAGS) -c/,
+         q/.f90/ => q/$(FC) $(FPPFLAGS) $(FFLAGS) $(OTHERFLAGS) $(OTHER_FFLAGS) -c/,
+         # C files
+         q/.c/   => q/$(CC) $(CPPDEFS) $(CPPFLAGS) $(CFLAGS) $(OTHERFLAGS) $(OTHER_CFLAGS) -c/,
+         # C++ files
+         q/.C/   => q/$(CXX) $(CPPDEFS) $(CPPFLAGS) $(CXXFLAGS) $(OTHERFLAGS) $(OTHER_CXXFLAGS) -c/,
+         q/.cc/  => q/$(CXX) $(CPPDEFS) $(CPPFLAGS) $(CXXFLAGS) $(OTHERFLAGS) $(OTHER_CXXFLAGS) -c/,
+         q/.cpp/ => q/$(CXX) $(CPPDEFS) $(CPPFLAGS) $(CXXFLAGS) $(OTHERFLAGS) $(OTHER_CXXFLAGS) -c/,
+         q/.cxx/ => q/$(CXX) $(CPPDEFS) $(CPPFLAGS) $(CXXFLAGS) $(OTHERFLAGS) $(OTHER_CXXFLAGS) -c/,
+         q/.c++/ => q/$(CXX) $(CPPDEFS) $(CPPFLAGS) $(CXXFLAGS) $(OTHERFLAGS) $(OTHER_CXXFLAGS) -c/,
+         );
+}
 my %delim_match = ( q/'/ => q/'/,       # hash to find includefile delimiter pair
                     q/"/ => q/"/,
                     q/</ => q/>/ );
@@ -464,10 +486,16 @@ foreach $object ( sort @objects ) {
       print MAKEFILE "\n";
       &print_compile_cmd( $name, '.f90' );
       print MAKEFILE " -o \$@ \t\$(preproc)";
+      if ( $opt_gen_ptree ) {
+         print MAKEFILE " > ${object}_ptree";
+      }
    } else {
       &print_compile_cmd( $name, $suffix );
       &print_includes;
       print MAKEFILE "\t$source_of{$object}";
+      if ( $opt_gen_ptree ) {
+         print MAKEFILE " > ${object}_ptree";
+      }
    }
    print MAKEFILE "\n";
 

--- a/dev-utils/gen_parse_tree.sh
+++ b/dev-utils/gen_parse_tree.sh
@@ -1,0 +1,69 @@
+#!/bin/bash -e
+
+# Save various paths to use as shortcuts
+ROOTDIR=`pwd -P`/..
+MKMF_ROOT=${ROOTDIR}/build-utils/mkmf
+TEMPLATE_DIR=${ROOTDIR}/build-utils/makefile-templates
+MOM_ROOT=${ROOTDIR}/src/MOM6
+FMS_ROOT=${ROOTDIR}/src/FMS
+SHR_ROOT=${ROOTDIR}/src/CESM_share
+
+# Default values for CLI arguments
+COMPILER="flang_ptree"
+MACHINE="ncar"
+MEMORY_MODE="dynamic_symmetric"
+DEBUG=0 # False
+
+echo "Starting parse dump at `date`"
+echo "Compiler: $COMPILER"
+echo "Machine: $MACHINE"
+echo "Memory mode: $MEMORY_MODE"
+echo "Debug mode: $DEBUG"
+
+TEMPLATE=${TEMPLATE_DIR}/${MACHINE}-${COMPILER}.mk
+
+# Throw error if template does not exist:
+if [ ! -f $TEMPLATE ]; then
+  echo "ERROR: Template file $TEMPLATE does not exist."
+    echo "Templates are based on the machine and compiler arguments: machine-compiler.mk. Available templates are:"
+    ls ${TEMPLATE_DIR}/*.mk
+    echo "Exiting."
+  exit 1
+fi
+
+# Throw error if memory mode is not in [dynamic_symmetric, dynamic_nonsymmetric]
+if [[ "$MEMORY_MODE" != "dynamic_symmetric" && "$MEMORY_MODE" != "dynamic_nonsymmetric" ]]; then
+  echo "ERROR: Invalid memory mode '$MEMORY_MODE'. Valid options are 'dynamic_symmetric' or 'dynamic_nonsymmetric'."
+  exit 1
+fi
+
+BLD_PATH=${ROOTDIR}/bin/${COMPILER}
+
+# Create build directory if it does not exist
+if [ ! -d ${BLD_PATH} ]; then
+  mkdir -p ${BLD_PATH}
+fi
+
+MOM6_src_files=${MOM_ROOT}/{config_src/infra/FMS2,config_src/memory/${MEMORY_MODE},config_src/drivers/solo_driver,pkg/CVMix-src/src/shared,pkg/GSW-Fortran/modules,../MARBL/src,config_src/external,src/{*,*/*}}/
+
+# 1) Build FMS
+cd ${BLD_PATH}
+mkdir -p FMS
+cd FMS
+${MKMF_ROOT}/list_paths ${FMS_ROOT}
+# We need shr_const_mod.F90 and shr_kind_mod.F90 from ${SHR_ROOT}/src to build FMS
+echo "${SHR_ROOT}/src/shr_kind_mod.F90" >> path_names
+echo "${SHR_ROOT}/src/shr_const_mod.F90" >> path_names
+${MKMF_ROOT}/mkmf --gen-ptree -t ${TEMPLATE} -p libfms.a path_names
+make -j${JOBS} DEBUG=${DEBUG} libfms.a
+
+# 2) Build MOM6
+cd ${BLD_PATH}
+mkdir -p MOM6
+cd MOM6
+expanded=$(eval echo ${MOM6_src_files})
+${MKMF_ROOT}/list_paths -l ${expanded}
+${MKMF_ROOT}/mkmf --gen-ptree -t ${TEMPLATE} -o '-I../FMS' -p MOM6 -l '-L../FMS -lfms' path_names
+make -j${JOBS} DEBUG=${DEBUG} MOM6
+
+echo "Finished build at `date`"


### PR DESCRIPTION
This PR adds two flang makefile templates
 - ncar-flang: to build the standalone MOM6 executable
 - ncar-flang_ptree: to generate the flang parse tree
 