### PR TITLE
GCOV-based coverage report generation workflow

### DIFF
--- a/.github/workflows/matrix-compiler-smoketest.yaml
+++ b/.github/workflows/matrix-compiler-smoketest.yaml
@@ -1,5 +1,8 @@
 name: Build Inside NCAR HPC Development Containers
 
+# See the following link for more information on the NCAR HPC development containers:
+# https://hub.docker.com/u/ncarcisl
+
 on:
   workflow_dispatch:
   push:
@@ -27,9 +30,6 @@ jobs:
           # skip nvhpc/openmpi until CPU architecture mismatch gets resolved
           - compiler: nvhpc
             mpi: openmpi
-          # skip gcc14/openmpi, which appears to no longer exist under ncarcisl
-          - compiler: gcc14
-            mpi: openmpi
 
 
     name: Build
@@ -39,7 +39,7 @@ jobs:
         shell: bash -elo pipefail {0}
 
     container:
-      image: ncarcisl/cisldev-${{ matrix.arch }}-almalinux9-${{ matrix.compiler }}-${{ matrix.mpi }}${{ matrix.gpu == 'cuda' && '-cuda' || '' }}:devel
+      image: ncarcisl/cisldev-${{ matrix.arch }}-almalinux9-${{ matrix.compiler }}-${{ matrix.mpi }}${{ matrix.gpu == 'cuda' && '-cuda' || '' }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/matrix-compiler-smoketest.yaml
+++ b/.github/workflows/matrix-compiler-smoketest.yaml
@@ -27,6 +27,9 @@ jobs:
           # skip nvhpc/openmpi until CPU architecture mismatch gets resolved
           - compiler: nvhpc
             mpi: openmpi
+          # skip gcc14/openmpi, which appears to no longer exist under ncarcisl
+          - compiler: gcc14
+            mpi: openmpi
 
 
     name: Build

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ CPU_stats
 examples/*/*.nc
 examples/*/archive/
 RESTART/
+codecov/
 available_diags.000000
 exitcode
 logfile.000000.out

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,9 @@
 [submodule "src/MARBL"]
 	path = src/MARBL
 	url = https://github.com/marbl-ecosys/MARBL
+[submodule "dev-utils/flinspect"]
+	path = dev-utils/flinspect
+	url = https://github.com/alperaltuntas/flinspect
+[submodule "dev-utils/gcovlens"]
+	path = dev-utils/gcovlens
+	url = https://github.com/alperaltuntas/gcovlens.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,9 +10,6 @@
 [submodule "src/MARBL"]
 	path = src/MARBL
 	url = https://github.com/marbl-ecosys/MARBL
-[submodule "dev-utils/flinspect"]
-	path = dev-utils/flinspect
-	url = https://github.com/alperaltuntas/flinspect
 [submodule "dev-utils/gcovlens"]
 	path = dev-utils/gcovlens
 	url = https://github.com/alperaltuntas/gcovlens.git

--- a/build-utils/makefile-templates/ncar-gnu.mk
+++ b/build-utils/makefile-templates/ncar-gnu.mk
@@ -13,26 +13,27 @@ LD = mpif90 $(MAIN_PROGRAM)
 #  flags   #
 ############
 
-DEBUG =
+DEBUG = 0
+CODECOV = 0
 MAKEFLAGS += --jobs=$(shell grep '^processor' /proc/cpuinfo | wc -l)
 LDFLAGS :=
 
 FC_AUTO_R8 := -fdefault-real-8 -fdefault-double-8
 FPPFLAGS :=
 FFLAGS := $(FC_AUTO_R8) -fconvert=big-endian -ffree-line-length-none -ffixed-line-length-none -fallow-argument-mismatch  -fallow-invalid-boz -fcray-pointer
-FFLAGS_REPRO = -O
-FFLAGS_DEBUG = -g -Wall -Og -fbacktrace -ffpe-trap=zero,overflow -fcheck=bounds
-
 CFLAGS := -std=gnu99
-CFLAGS_REPRO = -O
-CFLAGS_DEBUG = -g -Wall -Og -fbacktrace -ffpe-trap=invalid,zero,overflow -fcheck=bounds
 
-ifeq ($(DEBUG),1)
-  FFLAGS += $(FFLAGS_DEBUG)
-  CFLAGS += $(CFLAGS_DEBUG)
-else
-  FFLAGS += $(FFLAGS_REPRO)
-  CFLAGS += $(CFLAGS_REPRO)
+# Compilation Mode-specific flags
+ifeq ($(CODECOV),1)
+	FFLAGS += -O0 -g -fprofile-arcs -ftest-coverage -fprofile-dir=./codecov/
+	CFLAGS += -O0 -g -fprofile-arcs -ftest-coverage -fprofile-dir=./codecov/
+	LDFLAGS += -fprofile-arcs -ftest-coverage -fprofile-dir=./codecov/
+else ifeq ($(DEBUG),1)
+	FFLAGS += -O0 -g -Wall -Og -fbacktrace -ffpe-trap=zero,overflow -fcheck=bounds
+	CFLAGS += -O0 -g -Wall -Og -fbacktrace -ffpe-trap=invalid,zero,overflow -fcheck=bounds
+else # Production build
+	FFLAGS += -O2
+	CFLAGS += -O2
 endif
 
 # NetCDF Flags

--- a/build.sh
+++ b/build.sh
@@ -134,17 +134,15 @@ if [ "$MACHINE" == "ncar" ]; then
   HOST=`hostname`
   # Load modules if on derecho
   if [ ! "${HOST:0:5}" == "crhtc" ] && [ ! "${HOST:0:6}" == "casper" ]; then
-    #module --force purge
-    #. /glade/u/apps/derecho/23.09/spack/opt/spack/lmod/8.7.24/gcc/7.5.0/c645/lmod/lmod/init/sh
-    #module load cesmdev/1.0 ncarenv/23.09
-    module reset
+    module --force purge
+    . /glade/u/apps/derecho/23.09/spack/opt/spack/lmod/8.7.24/gcc/7.5.0/c645/lmod/lmod/init/sh
+    module load cesmdev/1.0 ncarenv/23.09
     case $COMPILER in
       "intel" )
         module load craype intel/2023.2.1 mkl ncarcompilers/1.0.0 cmake cray-mpich/8.1.27 netcdf-mpi/4.9.2 parallel-netcdf/1.12.3 parallelio/2.6.2 esmf/8.6.0
         ;;
       "gnu" )
-        module load lcov gcc 
-        #module load craype gcc/12.2.0 cray-libsci/23.02.1.1 ncarcompilers/1.0.0 cmake cray-mpich/8.1.27 netcdf-mpi/4.9.2 parallel-netcdf/1.12.3 parallelio/2.6.2-debug esmf/8.6.0-debug
+        module load craype gcc/12.2.0 cray-libsci/23.02.1.1 ncarcompilers/1.0.0 cmake cray-mpich/8.1.27 netcdf-mpi/4.9.2 parallel-netcdf/1.12.3 parallelio/2.6.2-debug esmf/8.6.0-debug
         ;;
       "nvhpc" )
         module load craype nvhpc/23.7 ncarcompilers/1.0.0 cmake cray-mpich/8.1.27 netcdf-mpi/4.9.2 parallel-netcdf/1.12.3 parallelio/2.6.2 esmf/8.6.0

--- a/build.sh
+++ b/build.sh
@@ -13,13 +13,25 @@ COMPILER="intel"
 MACHINE="ncar"
 MEMORY_MODE="dynamic_symmetric"
 DEBUG=0 # False
+CODECOV=0 # False
+OVERRIDE=0 # False
 
 # Parse command line arguments
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         --help)
-            echo "Usage: $0 [--compiler <compiler>] [--machine <machine>] [--memory-mode <memory_mode>]"
-            echo "Default values: compiler=$COMPILER, machine=$MACHINE, memory_mode=$MEMORY_MODE"
+            echo "Usage: $0 [--compiler <compiler>] [--machine <machine>] [--memory-mode <memory_mode>] [--codecov] [--debug] [--override]"
+            echo "Build script for MOM6 with FMS."
+            echo "  --compiler <compiler>        Compiler to use (default: intel)"
+            echo "  --machine <machine>          Machine type (default: ncar)"
+            echo "  --memory-mode <memory_mode>  Memory mode (default: dynamic_symmetric)"
+            echo "  --codecov                    Enable code coverage (default: disabled)"
+            echo "  --debug                      Enable debug mode (default: disabled)"
+            echo "  --override                   If a build already exists, clear it and rebuild (default: false)"
+            echo "Examples:"
+            echo "  $0 --compiler nvhpc --machine ncar"
+            echo "  $0 --memory-mode dynamic_nonsymmetric"
+            echo "  $0 --compiler gnu --codecov"
             exit 0 ;;
         --compiler) 
             COMPILER="$2"
@@ -30,11 +42,15 @@ while [[ "$#" -gt 0 ]]; do
         --memory-mode)
             MEMORY_MODE="$2"
             shift ;;
+        --codecov)
+            CODECOV=1 ;;
         --debug)
             DEBUG=1 ;;
+        --override)
+            OVERRIDE=1 ;;
         *) 
             echo "Unknown parameter passed: $1"
-            echo "Usage: $0 [--compiler <compiler>] [--machine <machine>] [--memory-mode <memory_mode>]"
+            echo "Usage: $0 [--compiler <compiler>] [--machine <machine>] [--memory-mode <memory_mode>] [--codecov] [--debug] [--override]"
             exit 1 ;;
     esac
     shift
@@ -44,7 +60,9 @@ echo "Starting build at `date`"
 echo "Compiler: $COMPILER"
 echo "Machine: $MACHINE"
 echo "Memory mode: $MEMORY_MODE"
+echo "Code coverage enabled?: $CODECOV"
 echo "Debug mode: $DEBUG"
+echo "Override existing build?: $OVERRIDE"
 
 TEMPLATE=${TEMPLATE_DIR}/${MACHINE}-${COMPILER}.mk
 
@@ -60,6 +78,21 @@ fi
 # Throw error if memory mode is not in [dynamic_symmetric, dynamic_nonsymmetric]
 if [[ "$MEMORY_MODE" != "dynamic_symmetric" && "$MEMORY_MODE" != "dynamic_nonsymmetric" ]]; then
   echo "ERROR: Invalid memory mode '$MEMORY_MODE'. Valid options are 'dynamic_symmetric' or 'dynamic_nonsymmetric'."
+  exit 1
+fi
+
+# Throw error if code coverage is enabled but compiler is not gnu or flang
+# This check can be relaxed if and when CODECOV is taken into account in other makefile templates.
+# See ncar-gnu.mk as an example.
+if [[ $CODECOV -eq 1 && ( "$COMPILER" != "gnu" || "$MACHINE" != "ncar" ) ]]; then
+  echo "ERROR: Code coverage can only be enabled with the GNU compiler on the NCAR machine."
+  exit 1
+fi
+
+# Cannot specify --codecov with --debug
+if [[ $CODECOV -eq 1 && $DEBUG -eq 1 ]]; then
+  echo "ERROR: Cannot specify --codecov with --debug."
+  echo "Please choose one of the two options."
   exit 1
 fi
 
@@ -81,10 +114,14 @@ case $MACHINE in
 esac
 
 
-if [ "${DEBUG}" == 1 ]; then
-  BLD_PATH=${ROOTDIR}/bin/${COMPILER}-debug
-else
-  BLD_PATH=${ROOTDIR}/bin/${COMPILER}
+BLD_PATH=${ROOTDIR}/bin/${COMPILER}
+
+# If override is set, remove existing build directory
+if [ $OVERRIDE -eq 1 ]; then
+  if [ -d ${BLD_PATH} ]; then
+    echo "Removing existing build directory: ${BLD_PATH}"
+    rm -rf ${BLD_PATH}
+  fi
 fi
 
 # Create build directory if it does not exist
@@ -97,15 +134,17 @@ if [ "$MACHINE" == "ncar" ]; then
   HOST=`hostname`
   # Load modules if on derecho
   if [ ! "${HOST:0:5}" == "crhtc" ] && [ ! "${HOST:0:6}" == "casper" ]; then
-    module --force purge
-    . /glade/u/apps/derecho/23.09/spack/opt/spack/lmod/8.7.24/gcc/7.5.0/c645/lmod/lmod/init/sh
-    module load cesmdev/1.0 ncarenv/23.09
+    #module --force purge
+    #. /glade/u/apps/derecho/23.09/spack/opt/spack/lmod/8.7.24/gcc/7.5.0/c645/lmod/lmod/init/sh
+    #module load cesmdev/1.0 ncarenv/23.09
+    module reset
     case $COMPILER in
       "intel" )
         module load craype intel/2023.2.1 mkl ncarcompilers/1.0.0 cmake cray-mpich/8.1.27 netcdf-mpi/4.9.2 parallel-netcdf/1.12.3 parallelio/2.6.2 esmf/8.6.0
         ;;
       "gnu" )
-        module load craype gcc/12.2.0 cray-libsci/23.02.1.1 ncarcompilers/1.0.0 cmake cray-mpich/8.1.27 netcdf-mpi/4.9.2 parallel-netcdf/1.12.3 parallelio/2.6.2-debug esmf/8.6.0-debug
+        module load lcov gcc 
+        #module load craype gcc/12.2.0 cray-libsci/23.02.1.1 ncarcompilers/1.0.0 cmake cray-mpich/8.1.27 netcdf-mpi/4.9.2 parallel-netcdf/1.12.3 parallelio/2.6.2-debug esmf/8.6.0-debug
         ;;
       "nvhpc" )
         module load craype nvhpc/23.7 ncarcompilers/1.0.0 cmake cray-mpich/8.1.27 netcdf-mpi/4.9.2 parallel-netcdf/1.12.3 parallelio/2.6.2 esmf/8.6.0
@@ -129,7 +168,7 @@ ${MKMF_ROOT}/list_paths ${FMS_ROOT}
 echo "${SHR_ROOT}/src/shr_kind_mod.F90" >> path_names
 echo "${SHR_ROOT}/src/shr_const_mod.F90" >> path_names
 ${MKMF_ROOT}/mkmf -t ${TEMPLATE} -p libfms.a -c "-Duse_libMPI -Duse_netCDF -DSPMD" path_names
-make -j${JOBS} DEBUG=${DEBUG} libfms.a
+make -j${JOBS} DEBUG=${DEBUG} CODECOV=${CODECOV} libfms.a
 
 # 2) Build MOM6
 cd ${BLD_PATH}
@@ -138,6 +177,6 @@ cd MOM6
 expanded=$(eval echo ${MOM6_src_files})
 ${MKMF_ROOT}/list_paths -l ${expanded}
 ${MKMF_ROOT}/mkmf -t ${TEMPLATE} -o '-I../FMS' -p MOM6 -l '-L../FMS -lfms' -c '-Duse_libMPI -Duse_netCDF -DSPMD' path_names
-make -j${JOBS} DEBUG=${DEBUG} MOM6
+make -j${JOBS} DEBUG=${DEBUG} CODECOV=${CODECOV} MOM6
 
 echo "Finished build at `date`"

--- a/dev-utils/gen_gcov.sh
+++ b/dev-utils/gen_gcov.sh
@@ -34,7 +34,7 @@ cd "${CODECOV_DIR}" || {
 }
 
 # Find all .gcda files in the codecov directory
-find ./ -name "*.gcda" | while read -r gcda_file_path; do
+find ./ -name "*.gcda" -print0 | while IFS= read -r -d '' gcda_file_path; do
 echo "--------------------------------------"
     gcda_file_name=$(basename "${gcda_file_path}")
     gcda_file_default="${gcda_file_name//\#/\/}" # The default path of gcda if it were not in codecov/

--- a/dev-utils/gen_gcov.sh
+++ b/dev-utils/gen_gcov.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+# This script generates gcov files for a given MOM6-TURBO experiment run.
+# The experiment must be run with an executable built with coverage enabled
+# e.g., ./build.sh --compiler gnu --codecov . Doing so will generate the
+# necessary .gcno files under the build directory. Running the experiment
+# with this executable will generate the .gcda files under the codecov/
+# directory of the experiment, e.g., double_gyre/codecov/. After the
+# experiment is complete, this script can be run to generate the gcov
+# files. You can then run gcovlens to generate html reports.
+
+# Usage: ./gen_gcov.sh <experiment_directory>
+
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 <experiment_directory>"
+  exit 1
+fi
+
+EXPERIMENT_DIR=$1
+CODECOV_DIR="${EXPERIMENT_DIR}/codecov"
+
+if [ ! -d "${CODECOV_DIR}" ]; then
+  echo ""
+  echo "Error: Codecov directory does not exist: ${CODECOV_DIR}"
+  echo "       Please make sure to run the experiment with a MOM6 executable "
+  echo "       built with coverage enabled: ./build.sh --compiler gnu --codecov"
+  echo ""
+  exit 1
+fi
+
+cd "${CODECOV_DIR}" || {
+  echo "Error: Could not change to directory ${CODECOV_DIR}"
+  exit 1
+}
+
+# Find all .gcda files in the codecov directory
+find ./ -name "*.gcda" | while read -r gcda_file_path; do
+echo "--------------------------------------"
+    gcda_file_name=$(basename "${gcda_file_path}")
+    gcda_file_default="${gcda_file_name//\#/\/}" # The default path of gcda if it were not in codecov/
+    gcda_file_name_default=$(basename "${gcda_file_default}")  # The default name of the gcda file
+    obj_dir="${gcda_file_default%/*}"  # The directory of the object file
+    gcno_file_name="${gcda_file_name_default/.gcda/.gcno}"  # The corresponding gcno file name
+    gcno_file_path="${obj_dir}/${gcno_file_name}"  # The full path of the corresponding gcno file
+
+    # Copy the gcda file to the object directory (Otherwise gcov reports 0.0 line coverage for some reason)
+    cp "${gcda_file_path}" "${obj_dir}/${gcda_file_name_default}"  # Copy the gcda file to the object directory
+
+    # Execute gcov command
+    if [ -f "${gcno_file_path}" ]; then
+        cmd="gcov -o ${obj_dir} ${gcda_file_name_default}"
+        echo "Command: ${cmd}"
+        eval "${cmd}"
+    else
+        echo "WARNING: Corresponding gcno file does not exist: ${gcno_file_path}"
+        continue
+    fi
+done
+
+# Print a message indicating completion
+echo "Generated gcov files in ${CODECOV_DIR}."
+echo "You can now run gcovlens to generate html reports."

--- a/examples/utils/Makefile
+++ b/examples/utils/Makefile
@@ -1,6 +1,13 @@
 timestamp = $(shell date +%Y%m%d_%H%M%S)
 untracked_files = $(shell git ls-files --others --directory --exclude=archive)
 
+coverage:
+ifneq ($(strip $(base)),)
+	../../dev-utils/gen_gcov.sh $(base)
+endif
+	../../dev-utils/gen_gcov.sh .
+	../../dev-utils/gcovlens/gcovlens.py $(base) .
+
 clean:
 	rm -rf $(untracked_files)
 


### PR DESCRIPTION
## Description

This PR introduces a GCOV-based coverage report generation workflow:
 - Build with coverage using a new --codecov flag.
 - Generate .gcov files after a run.
 - Produce interactive HTML reports (single-run and diff) with a new Python tool, gcovlens.
 - Makefile shortcuts for one-command report generation from experiment dirs.


## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

Fixes #9, #18

## Changes Made

<!-- Provide a detailed list of changes made in this PR -->

- build.sh
  - New CLI flag: `--codecov`
  - Builds a coverage-instrumented executable.
  - Currently supported: GNU compiler on derecho. Extending to other machines/compilers will require changes to the Makefile templates.

- gen_gcov.sh
  - New helper script to generate `.gcov` files for an experiment that was run with a `--codecov` build.

- gcovlens (new submodule/tool): Python tool that turns .gcov outputs into:
  - Single-run coverage reports; and
  - Two-run diff reports (A vs. B).
  - HTML includes sortable tables, per-file detail pages, syntax highlighting, and a minimap for quick navigation.
  - Also supports Markdown summary output.

- Experiment Makefiles
  - New/updated `make coverage` targets to quickly generate reports after a run.

### Usage

Compile MOM6 with code coverage instrumentation:
```
./build.sh --compiler gnu --codecov
```

Single run:
```
cd experiments/double_gyre
# Run with a --codecov build of MOM6 first:
../../bin/gnu/MOM6/MOM6

# Then generate coverage report:
make coverage
```

Two runs (comparison):

```
# Assume double_gyre is your “base” run; now run the “benchmark” experiment:
cd experiments/benchmark
mpiexec -n 16 ../../bin/gnu/MOM6/MOM6

# Generate a diff report vs. the base experiment:
make coverage base=../double_gyre
```

Running make coverage will produce one or more coverage_\*.html files in the experiment directory.
Per-file detail pages are written into a sibling directory named like coverage_\*_files/.

## Testing

<!-- Describe the testing performed to verify your changes -->

### Test Environment
- [x] Tested on derecho

### Compiler(s) Tested
- [x] GNU

### Test Cases
<!-- Describe specific test cases run -->
 
- [x] Manual testing performed
- [x] Examples run successfully

### Test Results
<!-- Describe test results or link to test output -->

## Performance Impact

<!-- If applicable, describe any performance implications -->

- [x] No performance impact expected

<!-- If there's a performance impact, provide details -->

## Documentation

<!-- Mark completed documentation tasks -->

- [x] Developer documentation updated: https://github.com/TURBO-ESM/turbo-stack/wiki/Code-Coverage-with-gcovlens-(GCOV)

## Checklist

<!-- Verify all items before submitting the PR -->

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
