### PR TITLE
New CI test to build MOM6 with both TIM and FMS2

### DIFF
--- a/.github/workflows/build-tests.yaml
+++ b/.github/workflows/build-tests.yaml
@@ -62,7 +62,7 @@ jobs:
       - name: Build MOM6 with TIM
         run: |
           ./build.sh --compiler ${COMPILER_FAMILY} --machine container --infra TIM
-          if [[ ! `nm --print-armap bin/${COMPILER_FAMILY}/MOM6-infra-TIM/libinfra-TIM.a | grep tim_com` ]]; then
+          if [[ ! `nm --print-armap bin/${COMPILER_FAMILY}/MOM6_using_TIM/MOM6-infra/libinfra-TIM.a | grep tim_com` ]]; then
             echo "ERROR: Did not find tim_com in libinfra-TIM.a (did TIM module change name?)"
             exit 1
           fi
@@ -70,7 +70,7 @@ jobs:
       - name: Build MOM6 with FMS2
         run: |
           ./build.sh --compiler ${COMPILER_FAMILY} --machine container --infra FMS2
-          if [[ `nm --print-armap bin/${COMPILER_FAMILY}/MOM6-infra-FMS2/libinfra-FMS2.a | grep tim_com` ]]; then
+          if [[ `nm --print-armap bin/${COMPILER_FAMILY}/MOM6_using_FMS2/MOM6-infra/libinfra-FMS2.a | grep tim_com` ]]; then
             echo "ERROR: Found tim_com in libinfra-FMS2.a (=> using TIM infra, not FMS)"
             exit 1
           fi

--- a/.github/workflows/code-coverage-reports.yaml
+++ b/.github/workflows/code-coverage-reports.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Run double gyre (instrumented build)
         run: |
           cd examples/double_gyre
-          mpiexec -n 2 --allow-run-as-root ../../bin/gcc/MOM6/MOM6
+          mpiexec -n 2 --allow-run-as-root ../../bin/gcc/MOM6_using_FMS2/MOM6/MOM6
           make coverage
           cd ../..
       
@@ -41,7 +41,7 @@ jobs:
         run: |
           cd examples/benchmark
           echo "#override DAYMAX = 0.1" >> MOM_override
-          mpiexec -n 2 --allow-run-as-root ../../bin/gcc/MOM6/MOM6
+          mpiexec -n 2 --allow-run-as-root ../../bin/gcc/MOM6_using_FMS2/MOM6/MOM6
           make coverage
           make coverage base=../double_gyre
           cd ../..

--- a/.github/workflows/matrix-compiler-smoketest.yaml
+++ b/.github/workflows/matrix-compiler-smoketest.yaml
@@ -86,4 +86,4 @@ jobs:
         run: |
           echo "Running double gyre test..."
           cd ./examples/double_gyre
-          mpiexec -n 2 ${{ matrix.extra_mpiexec_args }} ../../bin/${COMPILER_FAMILY}/MOM6/MOM6
+          mpiexec -n 2 ${{ matrix.extra_mpiexec_args }} ../../bin/${COMPILER_FAMILY}/MOM6_using_FMS2/MOM6/MOM6

--- a/README.md
+++ b/README.md
@@ -36,7 +36,13 @@ Optionally, you can specify a compiler other than the default `intel`, e.g.,
 ./build.sh --compiler gnu
 ```
 
-Once the build is complete, the executable will be at `bin/[COMPILER]/MOM6/MOM6`.
+You can also specify an infrastructure layer other than the default `FMS2`, e.g.,
+
+```bash
+./build.sh --infra TIM
+```
+
+Once the build is complete, the executable will be at `bin/[COMPILER]/MOM6_using_[INFRA]/MOM6/MOM6`.
 
 
 ### Building the MOM6 executable on other machines:
@@ -77,13 +83,13 @@ To run one of the lightweight examples, such as `double_gyre`, you can execute t
 
 ```bash
 cd examples/double_gyre/
-../../bin/intel/MOM6/MOM6
+../../bin/intel/MOM6_using_FMS2/MOM6/MOM6
 ```
 
 For computationally more expensive examples, such as `benchmark`, you need to run MOM6 in parallel.
 
 ```bash
-mpirun ../../bin/intel/MOM6/MOM6
+mpirun ../../bin/intel/MOM6_using_FMS2/MOM6/MOM6
 ```
 
 Example job submission scripts are provided in all of the example directories. Make sure to adjust 

--- a/build.sh
+++ b/build.sh
@@ -196,7 +196,7 @@ if [ -z "${JOBS}"  ]; then
 fi
 echo "Using ${JOBS} jobs"
 
-BLD_PATH=${ROOTDIR}/bin/${COMPILER}
+BLD_PATH=${ROOTDIR}/bin/${COMPILER}/MOM6_using_${INFRA}
 
 # If override is set, remove existing build directory
 if [ $OVERRIDE -eq 1 ]; then
@@ -329,8 +329,8 @@ ${MKMF_ROOT}/mkmf -t ${TEMPLATE} -p lib${INFRA}.a -o "${INFRA_INCLUDE_FLAGS}" -l
 make -j${JOBS} DEBUG=${DEBUG} CODECOV=${CODECOV} OFFLOAD=${OFFLOAD} lib${INFRA}.a
 
 
-LINKING_FLAGS="-L../MOM6-infra-${INFRA} -linfra-${INFRA} -L../${INFRA} -l${INFRA}"
-INCLUDE_OPTS="-I../${INFRA} -I../MOM6-infra-${INFRA}"
+LINKING_FLAGS="-L../MOM6-infra -linfra-${INFRA} -L../${INFRA} -l${INFRA}"
+INCLUDE_OPTS="-I../${INFRA} -I../MOM6-infra"
 if [[ "${INFRA}" == "TIM" ]]; then
   INCLUDE_OPTS="${INCLUDE_OPTS} ${AMREX_INCLUDE_FLAGS}"
   # -lstdc++ link flag needed for older ocmpilers (especially non llvm based ones)
@@ -339,8 +339,8 @@ fi
 
 # 2) Build MOM6 infra
 cd ${BLD_PATH}
-mkdir -p MOM6-infra-${INFRA}
-cd MOM6-infra-${INFRA}
+mkdir -p MOM6-infra
+cd MOM6-infra
 expanded=$(eval echo ${MOM6_infra_files})
 ${MKMF_ROOT}/list_paths -l ${expanded}
 ${MKMF_ROOT}/mkmf -t ${TEMPLATE} -o "${INCLUDE_OPTS}" -p ${LIBINFRA} -c "-Duse_libMPI -Duse_netCDF -DSPMD" path_names
@@ -361,7 +361,7 @@ if [ $UNIT_TESTS_ONLY -eq 1 ]; then
   NetCDF_C_PREFIX_PATH=$(nc-config --prefix)             \
   NetCDF_Fortran_PREFIX_PATH=$(nf-config --prefix)       \
   PATH_TO_BACKEND_LIB="${BLD_PATH}/${INFRA}"             \
-  PATH_TO_LIBINFRA="${BLD_PATH}/MOM6-infra-${INFRA}"     \
+  PATH_TO_LIBINFRA="${BLD_PATH}/MOM6-infra"              \
   LIB_INFRA=${INFRA}                                     \
   CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}                   \
     make -j${JOBS} -C ${UNIT_TEST_ROOT} build_unit_tests

--- a/examples/benchmark/job-derecho.sh
+++ b/examples/benchmark/job-derecho.sh
@@ -11,5 +11,6 @@
 export TMPDIR=${SCRATCH}/${USER}/temp && mkdir -p $TMPDIR
 
 COMPILER=intel
+INFRA=FMS2
 
-mpiexec ../../bin/${COMPILER}/MOM6/MOM6
+mpiexec ../../bin/${COMPILER}/MOM6_using_${INFRA}/MOM6/MOM6

--- a/examples/cesm_t232/job-derecho.sh
+++ b/examples/cesm_t232/job-derecho.sh
@@ -17,5 +17,6 @@ if [ ! -d /glade/work/altuntas/mom6.standalone.runs/cesm/INPUT/t232/ ]; then
 fi
 
 COMPILER=intel
+INFRA=FMS2
 
-mpiexec ../../bin/${COMPILER}/MOM6/MOM6
+mpiexec ../../bin/${COMPILER}/MOM6_using_${INFRA}/MOM6/MOM6

--- a/examples/cesm_t232_marbl/job-derecho.sh
+++ b/examples/cesm_t232_marbl/job-derecho.sh
@@ -17,5 +17,6 @@ if [ ! -d /glade/work/altuntas/mom6.standalone.runs/cesm/INPUT/t232/ ]; then
 fi
 
 COMPILER=intel
+INFRA=FMS2
 
-mpiexec ../../bin/${COMPILER}/MOM6/MOM6
+mpiexec ../../bin/${COMPILER}/MOM6_using_${INFRA}/MOM6/MOM6

--- a/examples/double_gyre/job-derecho.sh
+++ b/examples/double_gyre/job-derecho.sh
@@ -11,5 +11,6 @@
 export TMPDIR=${SCRATCH}/${USER}/temp && mkdir -p $TMPDIR
 
 COMPILER=intel
+INFRA=FMS2
 
-mpiexec ../../bin/${COMPILER}/MOM6/MOM6
+mpiexec ../../bin/${COMPILER}/MOM6_using_${INFRA}/MOM6/MOM6

--- a/examples/nw2_0.25deg_N15_baseline_hmix5/job-derecho.sh
+++ b/examples/nw2_0.25deg_N15_baseline_hmix5/job-derecho.sh
@@ -12,5 +12,6 @@
 export TMPDIR=${SCRATCH}/${USER}/temp && mkdir -p $TMPDIR
 
 COMPILER=intel
+INFRA=FMS2
 
-mpiexec ../../bin/${COMPILER}/MOM6/MOM6
+mpiexec ../../bin/${COMPILER}/MOM6_using_${INFRA}/MOM6/MOM6


### PR DESCRIPTION
## Description

On the current `main`, running `./build.sh --infra FMS2` after `./build.sh --infra TIM` will not actually switch to the FMS2 infrastructure layer; `libinfra-FMS2.a` will use the object files built with TIM. This causes a failure in the unit testing, but MOM6 just silently runs with the wrong infrastructure.

<!-- Provide a brief description of the changes in this pull request -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code maintenance (refactoring, optimization, etc.)
- [ ] CI/CD changes

## Related Issues

<!-- Link any related issues using keywords like "Fixes #123", "Closes #456", "Related to #789" -->

Fixes #181

## Changes Made

<!-- Provide a detailed list of changes made in this PR -->

- Created a new CI test that builds `--infra TIM` and then `--infra FMS2` and makes sure there are no TIM modules in the FMS2 library.
- Updated `build.sh` to have different build directories for the different infrastructure layers

## Testing

1. Verified there are two ways to catch this failure:

   ```
   ./build.sh --machine ubuntu --compiler gnu --infra TIM
   ./build.sh --machine ubuntu --compiler gnu --infra FMS2
   ```

   creates a `libinfra-FMS2.a` file that contains TIM functions (`nm --print-armap bin/gnu/MOM6-infra/libinfra-FMS2.a | grep tim_com` shows some of the TIM checksum functions are being called), and

   ```
   ./build.sh --unit-tests-only --machine ubuntu --compiler gnu --infra TIM
   ./build.sh --unit-tests-only --machine ubuntu --compiler gnu --infra FMS2
   ```

   fails because the unit tests need to be linked to AMReX when calling the TIM infrastructure layer, but in the second command `build.sh` thinks it is linking to FMS2 (which doesn't need AMReX)

2. Updated `build.sh` to make sure we can switch infrastructure layers cleanly, and then verified the above commands work

### Test Environment
- [x] Tested on derecho
- [x] Tested locally
- [ ] Other: _______________

### Compiler(s) Tested
- [x] Intel
- [x] GNU
- [ ] NVHPC
- [ ] Other: _______________

### Test Cases
<!-- Describe specific test cases run -->

- [x] All existing tests pass
- [x] New tests added and pass
- [ ] Manual testing performed
- [ ] Examples run successfully

### Test Results

```
100% tests passed, 0 tests failed out of 30
```

## Performance Impact

<!-- If applicable, describe any performance implications -->

- [x] No performance impact expected
- [ ] Performance improvement
- [ ] Potential performance impact (explain below)

<!-- If there's a performance impact, provide details -->

## Documentation

<!-- Mark completed documentation tasks -->

- [ ] Code comments updated
- [ ] README updated
- [ ] User documentation updated
- [ ] Developer documentation updated
- [x] No documentation changes needed

## Checklist

<!-- Verify all items before submitting the PR -->

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published