### PR TITLE
If INFRA==TIM, build MOM6 with -D_TIM

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -253,7 +253,7 @@ fi
 MOM6_infra_files=${MOM_ROOT}/{config_src/memory/${MEMORY_MODE},config_src/infra/${INFRA}}
 MOM6_src_files=${MOM_ROOT}/{config_src/memory/${MEMORY_MODE},config_src/drivers/solo_driver,pkg/CVMix-src/src/shared,pkg/GSW-Fortran/modules,../MARBL/src,config_src/external,src/{*,*/*}}/
 
-# 0) Build AMReX if needed
+# 0) Build AMReX if needed; also set -D_TIM for MOM6 build
 if [[ "${INFRA}" == "TIM" ]]; then
   # Check if AMREX_INSTALL_PATH was provided or if need to build from submodule first.
   if [[ -z "${AMREX_INSTALL_PATH}" ]]; then
@@ -275,6 +275,8 @@ if [[ "${INFRA}" == "TIM" ]]; then
   fi
   AMREX_LINK_FLAGS="-L${AMREX_INSTALL_PATH}/lib -lamrex"
   AMREX_INCLUDE_FLAGS="-I${AMREX_INSTALL_PATH}/include"
+
+  FFLAGS="-D_TIM"
 fi
 
 # 0a) Build pFUnit if needed
@@ -358,7 +360,7 @@ else
   cd MOM6
   expanded=$(eval echo ${MOM6_src_files})
   ${MKMF_ROOT}/list_paths -l ${expanded}
-  ${MKMF_ROOT}/mkmf -t ${TEMPLATE} -o "${INCLUDE_OPTS}" -p MOM6 -l "${LINKING_FLAGS}" -c '-Duse_libMPI -Duse_netCDF -DSPMD' path_names
+  ${MKMF_ROOT}/mkmf -t ${TEMPLATE} -o "${INCLUDE_OPTS}" -p MOM6 -l "${LINKING_FLAGS}" -c "${FFLAGS} -Duse_libMPI -Duse_netCDF -DSPMD" path_names
   make -j${JOBS} DEBUG=${DEBUG} CODECOV=${CODECOV} OFFLOAD=${OFFLOAD} MOM6
 fi
 


### PR DESCRIPTION
## Description

Add `FFLAGS` variable to `build.sh`, set it to `-D_TIM` if using TIM infrastructure; then pass this flag to the MOM6 build.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code maintenance (refactoring, optimization, etc.)
- [ ] CI/CD changes

## Related Issues

Fixes #223 

## Changes Made

Add `FFLAGS` to arguments passed to `mkmf` for MOM6 build; when infrastructure is TIM, make sure `FFLAGS=-D_TIM`

## Testing

Built using `dev/turbo` and the latest `TIM`, verified we see `-D_TIM` when using TIM and not when using FMS2. Also ran double gyre example, though there's no good way to verify that we took the branch of code we were expecting to take when `PPM_LIMIT_POS_MODE=AMREX`

### Test Environment
- [ ] Tested on derecho
- [x] Tested locally
- [ ] Other: _______________

### Compiler(s) Tested
- [ ] Intel
- [x] GNU
- [ ] NVHPC
- [ ] Other: _______________

### Test Cases
Just ran double gyre; this will not impact unit tests at all

- [x] All existing tests pass
- [ ] New tests added and pass
- [ ] Manual testing performed
- [ ] Examples run successfully

### Test Results
double gyre example ran as expected

## Performance Impact

<!-- If applicable, describe any performance implications -->

- [x] No performance impact expected
- [ ] Performance improvement
- [ ] Potential performance impact (explain below)

<!-- If there's a performance impact, provide details -->

## Documentation

<!-- Mark completed documentation tasks -->

- [ ] Code comments updated
- [ ] README updated
- [ ] User documentation updated
- [ ] Developer documentation updated
- [x] No documentation changes needed

## Checklist

<!-- Verify all items before submitting the PR -->

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published (sort of: they're on `dev/turbo-debug`
