### PR TITLE
Update derecho compilers

### DIFF
--- a/build-utils/makefile-templates/ncar-gnu.mk
+++ b/build-utils/makefile-templates/ncar-gnu.mk
@@ -21,7 +21,7 @@ LDFLAGS :=
 FC_AUTO_R8 := -fdefault-real-8 -fdefault-double-8
 FPPFLAGS :=
 FFLAGS := $(FC_AUTO_R8) -fconvert=big-endian -ffree-line-length-none -ffixed-line-length-none -fallow-argument-mismatch  -fallow-invalid-boz -fcray-pointer -fno-range-check
-CFLAGS := -std=gnu99
+CFLAGS := -std=gnu99 -DHAVE_GETTID
 
 CXXFLAGS := -std=c++17
 

--- a/build-utils/makefile-templates/ncar-intel.mk
+++ b/build-utils/makefile-templates/ncar-intel.mk
@@ -23,7 +23,7 @@ FFLAGS := $(FC_AUTO_R8) -qno-opt-dynamic-align  -convert big_endian -assume byte
 FFLAGS_DEBUG = -O0 -g -check uninit -check bounds -check nopointer -fpe0 -check noarg_temp_created # CESM uses -check pointers, that throws an error, changed to nopointer
 FFLAGS_REPRO = -O2 -debug minimal
 
-CFLAGS := -qno-opt-dynamic-align -fp-model precise -std=gnu99  -no-fma -qopt-report -march=core-avx2
+CFLAGS := -qno-opt-dynamic-align -fp-model precise -std=gnu99  -no-fma -qopt-report -march=core-avx2 -DHAVE_GETTID
 CFLAGS_REPRO= -O2 -debug minimal
 CFLAGS_DEBUG = -O0 -g
 

--- a/build-utils/makefile-templates/ncar-nvhpc.mk
+++ b/build-utils/makefile-templates/ncar-nvhpc.mk
@@ -6,7 +6,7 @@
 
 FC = ftn
 CC = cc
-CXX = c++
+CXX = CC
 LD = ftn $(MAIN_PROGRAM)
 
 ############

--- a/build-utils/makefile-templates/ncar-nvhpc.mk
+++ b/build-utils/makefile-templates/ncar-nvhpc.mk
@@ -39,7 +39,7 @@ else
 endif
 
 ifeq ($(OFFLOAD),1)
-  FFLAGS += -mp=gpu -gpu=cc80 -fopenmp -Minfo=accel
+  FFLAGS += -mp=gpu -gpu=cc80 -fopenmp -stdpar -Minfo=accel
   CFLAGS += -mp=gpu -gpu=cc80
   LDFLAGS += -mp=gpu -lmpi_gtl_cuda
 endif

--- a/build-utils/makefile-templates/ncar-nvhpc.mk
+++ b/build-utils/makefile-templates/ncar-nvhpc.mk
@@ -23,7 +23,7 @@ FPPFLAGS := $(shell pkg-config --cflags yaml-0.1)
 FFLAGS = $(FC_AUTO_R8) -Mnofma -i4 -gopt  -time -Mextend -byteswapio -Mflushz -Kieee -tp=zen3
 
 
-CFLAGS = -gopt -time -Mnofma
+CFLAGS = -gopt -time -Mnofma -DHAVE_GETTID
 CPPFLAGS := $(shell pkg-config --cflags yaml-0.1)
 
 CXXFLAGS := --std=c++17
@@ -34,19 +34,14 @@ ifeq ($(DEBUG),1)
   FFLAGS += -O0 -g
   CFLAGS += -O0 -g
 else
-  ifeq ($(OFFLOAD),1)
-    FFLAGS += -O0
-    CFLAGS += -O0
-  else
     FFLAGS += -O2
     CFLAGS += -O2
-  endif
 endif
 
 ifeq ($(OFFLOAD),1)
-  FFLAGS += -mp=gpu -gpu=cc80 -fopenmp -Minfo=all
+  FFLAGS += -mp=gpu -gpu=cc80 -fopenmp -Minfo=accel
   CFLAGS += -mp=gpu -gpu=cc80
-  LDFLAGS += -mp=gpu
+  LDFLAGS += -mp=gpu -lmpi_gtl_cuda
 endif
 
 # NetCDF Flags

--- a/build.sh
+++ b/build.sh
@@ -227,21 +227,15 @@ if [ "$MACHINE" == "ncar" ]; then
   # Load modules if on derecho
   if [ ! "${HOST:0:5}" == "crhtc" ] && [ ! "${HOST:0:6}" == "casper" ]; then
     module --force purge
-    . /glade/u/apps/derecho/23.09/spack/opt/spack/lmod/8.7.24/gcc/7.5.0/c645/lmod/lmod/init/sh
-    module load cesmdev/1.0 ncarenv/23.09
     case $COMPILER in
       "intel" )
-        module load craype intel/2023.2.1 mkl ncarcompilers/1.0.0 cmake cray-mpich/8.1.27 netcdf-mpi/4.9.2 parallel-netcdf/1.12.3 parallelio/2.6.2 esmf/8.6.0
+        module load ncarenv/25.10 craype/2.7.34 intel/2025.2.1 ncarcompilers/1.1.0 libfabric/1.22.0 cray-mpich/8.1.32 hdf5/1.14.6 netcdf/4.9.3 cmake
         ;;
       "gnu" )
-        module load craype gcc/12.2.0 cray-libsci/23.02.1.1 ncarcompilers/1.0.0 cmake cray-mpich/8.1.27 netcdf-mpi/4.9.2 parallel-netcdf/1.12.3 parallelio/2.6.2-debug esmf/8.6.0-debug
+        module load ncarenv/25.10 craype/2.7.34 gcc/14.3.0 ncarcompilers/1.1.0 hdf5/1.14.6 netcdf/4.9.3 libfabric/1.22.0 cray-mpich/8.1.32
         ;;
       "nvhpc" )
-        if [ $OFFLOAD -eq 1 ]; then
-          module load craype nvhpc/24.9 ncarcompilers/1.0.0 cmake cray-mpich/8.1.29 netcdf-mpi/4.9.2 parallel-netcdf/1.12.3 cuda/12.2.1
-        else
-          module load craype nvhpc/23.7 ncarcompilers/1.0.0 cmake cray-mpich/8.1.27 netcdf-mpi/4.9.2 parallel-netcdf/1.12.3
-        fi
+        module load ncarenv/25.10 cuda/12.9.0 cmake/3.31.8 hdf5/1.14.6 libfabric/1.22.0 craype/2.7.34 nvhpc/25.9 ncarcompilers/1.1.0 netcdf/4.9.3 cray-mpich/8.1.32 cmake
         ;;
       *)
         echo "Not loading any special modules for ${COMPILER}"

--- a/build.sh
+++ b/build.sh
@@ -226,16 +226,16 @@ if [ "$MACHINE" == "ncar" ]; then
   HOST=$(hostname)
   # Load modules if on derecho
   if [ ! "${HOST:0:5}" == "crhtc" ] && [ ! "${HOST:0:6}" == "casper" ]; then
-    module --force purge
+    module reset
     case $COMPILER in
       "intel" )
         module load ncarenv/25.10 craype/2.7.34 intel/2025.2.1 ncarcompilers/1.1.0 libfabric/1.22.0 cray-mpich/8.1.32 hdf5/1.14.6 netcdf/4.9.3 cmake
         ;;
       "gnu" )
-        module load ncarenv/25.10 craype/2.7.34 gcc/14.3.0 ncarcompilers/1.1.0 hdf5/1.14.6 netcdf/4.9.3 libfabric/1.22.0 cray-mpich/8.1.32
+        module load ncarenv/25.10 craype/2.7.34 gcc/14.3.0 ncarcompilers/1.1.0 hdf5/1.14.6 netcdf/4.9.3 libfabric/1.22.0 cray-mpich/8.1.32 cmake
         ;;
       "nvhpc" )
-        module load ncarenv/25.10 cuda/12.9.0 cmake/3.31.8 hdf5/1.14.6 libfabric/1.22.0 craype/2.7.34 nvhpc/25.9 ncarcompilers/1.1.0 netcdf/4.9.3 cray-mpich/8.1.32 cmake
+        module load ncarenv/25.10 cuda/12.9.0 hdf5/1.14.6 libfabric/1.22.0 craype/2.7.34 nvhpc/25.9 ncarcompilers/1.1.0 netcdf/4.9.3 cray-mpich/8.1.32 cmake
         ;;
       *)
         echo "Not loading any special modules for ${COMPILER}"

--- a/build.sh
+++ b/build.sh
@@ -229,13 +229,13 @@ if [ "$MACHINE" == "ncar" ]; then
     module reset
     case $COMPILER in
       "intel" )
-        module load ncarenv/25.10 craype/2.7.34 intel/2025.2.1 ncarcompilers/1.1.0 libfabric/1.22.0 cray-mpich/8.1.32 hdf5/1.14.6 netcdf/4.9.3 cmake
+        module load ncarenv/25.10 intel/2025.2.1 ncarcompilers/1.1.0 hdf5/1.14.6 netcdf/4.9.3 cmake
         ;;
       "gnu" )
-        module load ncarenv/25.10 craype/2.7.34 gcc/14.3.0 ncarcompilers/1.1.0 hdf5/1.14.6 netcdf/4.9.3 libfabric/1.22.0 cray-mpich/8.1.32 cmake
+        module load ncarenv/25.10 gcc/14.3.0 ncarcompilers/1.1.0 hdf5/1.14.6 netcdf/4.9.3 cmake
         ;;
       "nvhpc" )
-        module load ncarenv/25.10 cuda/12.9.0 hdf5/1.14.6 libfabric/1.22.0 craype/2.7.34 nvhpc/25.9 ncarcompilers/1.1.0 netcdf/4.9.3 cray-mpich/8.1.32 cmake
+        module load ncarenv/25.10 cuda/12.9.0 hdf5/1.14.6 nvhpc/25.9 ncarcompilers/1.1.0 netcdf/4.9.3 cmake
         ;;
       *)
         echo "Not loading any special modules for ${COMPILER}"

--- a/examples/double_gyre/job-gpu.sh
+++ b/examples/double_gyre/job-gpu.sh
@@ -8,6 +8,9 @@
 # Load modules to match compile-time environment
 module load cuda/12.9.0 nvhpc/25.9 cray-mpich/8.1.32
 
+### Set temp to scratch
+export TMPDIR=${SCRATCH}/${USER}/temp && mkdir -p $TMPDIR
+
 COMPILER=nvhpc
 INFRA=FMS2
 

--- a/examples/double_gyre/job-gpu.sh
+++ b/examples/double_gyre/job-gpu.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#PBS -A NCGD0067
+#PBS -N mom6_standalone_gpu
+#PBS -q main
+#PBS -l walltime=00:03:00
+#PBS -l select=1:ncpus=16:mpiprocs=2:ngpus=2
+
+# Load modules to match compile-time environment
+module load cuda/12.9.0 nvhpc/25.9 cray-mpich/8.1.32
+
+COMPILER=nvhpc
+INFRA=FMS2
+
+# Serial version works:
+../../bin/${COMPILER}/MOM6_using_${INFRA}/MOM6/MOM6
+
+# # Multiple ranks with GPU offloading fails at day 2.
+# mpiexec -n 2 -ppn 2 set_gpu_rank ../../bin/${COMPILER}/MOM6_using_${INFRA}/MOM6/MOM6

--- a/examples/double_gyre/job-gpu.sh
+++ b/examples/double_gyre/job-gpu.sh
@@ -6,7 +6,7 @@
 #PBS -l select=1:ncpus=4:mpiprocs=4:ngpus=4
 
 # Load modules to match compile-time environment
-module load cuda/12.9.0 nvhpc/25.9 cray-mpich/8.1.32
+module load ncarenv/25.10 cuda/12.9.0 hdf5/1.14.6 nvhpc/25.9 ncarcompilers/1.1.0 netcdf/4.9.3
 
 ### Set temp to scratch
 export TMPDIR=${SCRATCH}/${USER}/temp && mkdir -p $TMPDIR

--- a/examples/double_gyre/job-gpu.sh
+++ b/examples/double_gyre/job-gpu.sh
@@ -3,7 +3,7 @@
 #PBS -N mom6_standalone_gpu
 #PBS -q main
 #PBS -l walltime=00:03:00
-#PBS -l select=1:ncpus=16:mpiprocs=2:ngpus=2
+#PBS -l select=1:ncpus=4:mpiprocs=4:ngpus=4
 
 # Load modules to match compile-time environment
 module load cuda/12.9.0 nvhpc/25.9 cray-mpich/8.1.32
@@ -12,10 +12,6 @@ module load cuda/12.9.0 nvhpc/25.9 cray-mpich/8.1.32
 export TMPDIR=${SCRATCH}/${USER}/temp && mkdir -p $TMPDIR
 
 COMPILER=nvhpc
-INFRA=FMS2
+INFRA=TIM
 
-# Serial version works:
-../../bin/${COMPILER}/MOM6_using_${INFRA}/MOM6/MOM6
-
-# # Multiple ranks with GPU offloading fails at day 2.
-# mpiexec -n 2 -ppn 2 set_gpu_rank ../../bin/${COMPILER}/MOM6_using_${INFRA}/MOM6/MOM6
+mpiexec -n 4 -ppn 4 set_gpu_rank ../../bin/${COMPILER}/MOM6_using_${INFRA}/MOM6/MOM6


### PR DESCRIPTION
## Description

- Update the specified modules in `build.sh` to latest defaults for derecho.
- Update the makefile template for the `nvhpc` compiler. 
- Add a gpu offloading job submission script for double_gyre.

With these changes, we are able to build and run gpu-offloaded MOM6 on a single core/gpu with optimization flags when we switch to FMS `edoyango/ompoffload` and MOM6 `dev/gpu` branches. Multi-core/gpu runs fail at day 2, possibly due to MPI halo exchange and/or a binding issue.

Fixes: #230 

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code maintenance (refactoring, optimization, etc.)
- [ ] CI/CD changes


### Test Environment
- [x] Tested on derecho
- [ ] Tested locally
- [ ] Other: _______________

### Compiler(s) Tested
- [x] Intel
- [x] GNU
- [x] NVHPC
- [ ] Other: _______________

### Test Cases
<!-- Describe specific test cases run -->

- [ ] All existing tests pass
- [ ] New tests added and pass
- [x] Manual testing performed
- [ ] Examples run successfully