### PR TITLE
Update ncar-nvhpc build flags to improve performance

### DIFF
--- a/build-utils/amrex-utils/Makefile
+++ b/build-utils/amrex-utils/Makefile
@@ -1,8 +1,5 @@
 include $(TEMPLATE)
 
-# AMReX must build with the real host compiler. Under OFFLOAD the template sets
-# CXX to the MOM6 nvcc dispatch wrapper (for MOM6's own AMReX TUs); that wrapper
-# must not be AMReX's compiler. offload => nvhpc/ncar, where the host C++ is CC.
 ifeq ($(OFFLOAD),1)
   CXX := CC
 endif

--- a/build-utils/amrex-utils/Makefile
+++ b/build-utils/amrex-utils/Makefile
@@ -1,11 +1,19 @@
 include $(TEMPLATE)
 
+# AMReX must build with the real host compiler. Under OFFLOAD the template sets
+# CXX to the MOM6 nvcc dispatch wrapper (for MOM6's own AMReX TUs); that wrapper
+# must not be AMReX's compiler. offload => nvhpc/ncar, where the host C++ is CC.
+ifeq ($(OFFLOAD),1)
+  CXX := CC
+endif
+
 build_amrex:
 	cmake -S ${AMREX_ROOT} -B ${AMREX_BLD_PATH}          \
 		--install-prefix ${AMREX_INSTALL_PATH}           \
 		-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}           \
 		-DAMReX_FORTRAN_INTERFACES=YES                   \
 		-DAMReX_FORTRAN=YES                              \
+		$(AMREX_GPU_FLAGS)                               \
 		-DCMAKE_Fortran_COMPILER=$(shell which $(FC))    \
 		-DCMAKE_CXX_COMPILER=$(shell which $(CXX))       \
 		-DCMAKE_C_COMPILER=$(shell which $(CC))          \

--- a/build-utils/amrex-utils/Makefile
+++ b/build-utils/amrex-utils/Makefile
@@ -8,6 +8,7 @@ build_amrex:
 		-DAMReX_FORTRAN=YES                              \
 		-DCMAKE_Fortran_COMPILER=$(shell which $(FC))    \
 		-DCMAKE_CXX_COMPILER=$(shell which $(CXX))       \
-		-DCMAKE_C_COMPILER=$(shell which $(CC))       && \
+		-DCMAKE_C_COMPILER=$(shell which $(CC))          \
+		-DAMReX_TINY_PROFILE=ON                       && \
 	cmake --build ${AMREX_BLD_PATH} -j ${JOBS}        && \
 	cmake --install ${AMREX_BLD_PATH}

--- a/build-utils/makefile-templates/ncar-nvhpc.mk
+++ b/build-utils/makefile-templates/ncar-nvhpc.mk
@@ -41,15 +41,11 @@ endif
 ifeq ($(OFFLOAD),1)
   FFLAGS += -mp=gpu -gpu=cc80,mem:separate -stdpar=gpu -Minfo=accel
   CFLAGS += -mp=gpu -gpu=cc80,mem:separate
-  # The AMReX continuity bridge .cpp must be compiled by nvcc -- nvc++ (the Cray
-  # CC wrapper) cannot compile AMReX CUDA kernel launches. Route C++ through a
-  # dispatch wrapper: the bridge TUs -> nvcc -x cu, all other C++ -> CC. This is
-  # a no-op for the FMS2 build (it has no AMReX bridge files).
+  # Below is a temporary workaround to use the nvcc wrapper for C++ compilation
+  # Will be removed once the build system is updated.
   CXX = $(abspath $(dir $(MK_TEMPLATE))..)/nvcc-cxx-wrap.sh
   export NVCC_APPEND_FLAGS := --fmad=false
   AMREX_GPU_FLAGS := -DAMReX_GPU_BACKEND=CUDA -DAMReX_CUDA_ARCH=8.0 -DAMReX_MPI=NO -DAMReX_DIFFERENT_COMPILER=ON
-  # Final link (LD = ftn) pulls in the CUDA runtime and the C++ runtime so the
-  # nvcc-compiled AMReX/bridge objects resolve.
   LDFLAGS += -mp=gpu -cuda -gpu=cc80,mem:separate -c++libs -lmpi_gtl_cuda
 else
   CXXFLAGS += -Mnofma -Kieee

--- a/build-utils/makefile-templates/ncar-nvhpc.mk
+++ b/build-utils/makefile-templates/ncar-nvhpc.mk
@@ -41,7 +41,14 @@ endif
 ifeq ($(OFFLOAD),1)
   FFLAGS += -mp=gpu -gpu=cc80,mem:separate -stdpar=gpu -Minfo=accel
   CFLAGS += -mp=gpu -gpu=cc80,mem:separate
-  LDFLAGS += -mp=gpu -lmpi_gtl_cuda
+  # The AMReX continuity bridge .cpp must be compiled by nvcc -- nvc++ (the Cray
+  # CC wrapper) cannot compile AMReX CUDA kernel launches. Route C++ through a
+  # dispatch wrapper: the bridge TUs -> nvcc -x cu, all other C++ -> CC. This is
+  # a no-op for the FMS2 build (it has no AMReX bridge files).
+  CXX = /glade/work/altuntas/turbo-stack-iturbo/build-utils/nvcc-cxx-wrap.sh
+  # Final link (LD = ftn) pulls in the CUDA runtime and the C++ runtime so the
+  # nvcc-compiled AMReX/bridge objects resolve.
+  LDFLAGS += -mp=gpu -cuda -gpu=cc80,mem:separate -c++libs -lmpi_gtl_cuda
 endif
 
 # NetCDF Flags

--- a/build-utils/makefile-templates/ncar-nvhpc.mk
+++ b/build-utils/makefile-templates/ncar-nvhpc.mk
@@ -46,9 +46,12 @@ ifeq ($(OFFLOAD),1)
   # dispatch wrapper: the bridge TUs -> nvcc -x cu, all other C++ -> CC. This is
   # a no-op for the FMS2 build (it has no AMReX bridge files).
   CXX = /glade/work/altuntas/turbo-stack-iturbo/build-utils/nvcc-cxx-wrap.sh
+  export NVCC_APPEND_FLAGS := --fmad=false
   # Final link (LD = ftn) pulls in the CUDA runtime and the C++ runtime so the
   # nvcc-compiled AMReX/bridge objects resolve.
   LDFLAGS += -mp=gpu -cuda -gpu=cc80,mem:separate -c++libs -lmpi_gtl_cuda
+else
+  CXXFLAGS += -Mnofma -Kieee
 endif
 
 # NetCDF Flags

--- a/build-utils/makefile-templates/ncar-nvhpc.mk
+++ b/build-utils/makefile-templates/ncar-nvhpc.mk
@@ -45,7 +45,7 @@ ifeq ($(OFFLOAD),1)
   # CC wrapper) cannot compile AMReX CUDA kernel launches. Route C++ through a
   # dispatch wrapper: the bridge TUs -> nvcc -x cu, all other C++ -> CC. This is
   # a no-op for the FMS2 build (it has no AMReX bridge files).
-  CXX = /glade/work/altuntas/turbo-stack-iturbo/build-utils/nvcc-cxx-wrap.sh
+  CXX = $(abspath $(dir $(MK_TEMPLATE))..)/nvcc-cxx-wrap.sh
   export NVCC_APPEND_FLAGS := --fmad=false
   AMREX_GPU_FLAGS := -DAMReX_GPU_BACKEND=CUDA -DAMReX_CUDA_ARCH=8.0 -DAMReX_MPI=NO -DAMReX_DIFFERENT_COMPILER=ON
   # Final link (LD = ftn) pulls in the CUDA runtime and the C++ runtime so the

--- a/build-utils/makefile-templates/ncar-nvhpc.mk
+++ b/build-utils/makefile-templates/ncar-nvhpc.mk
@@ -47,6 +47,7 @@ ifeq ($(OFFLOAD),1)
   # a no-op for the FMS2 build (it has no AMReX bridge files).
   CXX = /glade/work/altuntas/turbo-stack-iturbo/build-utils/nvcc-cxx-wrap.sh
   export NVCC_APPEND_FLAGS := --fmad=false
+  AMREX_GPU_FLAGS := -DAMReX_GPU_BACKEND=CUDA -DAMReX_CUDA_ARCH=8.0 -DAMReX_MPI=NO -DAMReX_DIFFERENT_COMPILER=ON
   # Final link (LD = ftn) pulls in the CUDA runtime and the C++ runtime so the
   # nvcc-compiled AMReX/bridge objects resolve.
   LDFLAGS += -mp=gpu -cuda -gpu=cc80,mem:separate -c++libs -lmpi_gtl_cuda

--- a/build-utils/makefile-templates/ncar-nvhpc.mk
+++ b/build-utils/makefile-templates/ncar-nvhpc.mk
@@ -33,9 +33,11 @@ CXXFLAGS := --std=c++17
 ifeq ($(DEBUG),1)
   FFLAGS += -O0 -g
   CFLAGS += -O0 -g
+  CXXFLAGS += -O0 -g
 else
     FFLAGS += -O2
     CFLAGS += -O2
+    CXXFLAGS += -O2
 endif
 
 ifeq ($(OFFLOAD),1)
@@ -44,7 +46,8 @@ ifeq ($(OFFLOAD),1)
   # Below is a temporary workaround to use the nvcc wrapper for C++ compilation
   # Will be removed once the build system is updated.
   CXX = $(abspath $(dir $(MK_TEMPLATE))..)/nvcc-cxx-wrap.sh
-  export NVCC_APPEND_FLAGS := --fmad=false
+  # --fmad=false matches the Fortran -Mnofma. -Xptxas -O2 pins the device-code optimization level
+  export NVCC_APPEND_FLAGS := --fmad=false -Xptxas -O2
   AMREX_GPU_FLAGS := -DAMReX_GPU_BACKEND=CUDA -DAMReX_CUDA_ARCH=8.0 -DAMReX_MPI=NO -DAMReX_DIFFERENT_COMPILER=ON
   LDFLAGS += -mp=gpu -cuda -gpu=cc80,mem:separate -c++libs -lmpi_gtl_cuda
 else

--- a/build-utils/makefile-templates/ncar-nvhpc.mk
+++ b/build-utils/makefile-templates/ncar-nvhpc.mk
@@ -19,7 +19,7 @@ MAKEFLAGS += --jobs=8
 LDFLAGS :=
 
 FC_AUTO_R8 = -r8
-FPPFLAGS := $(shell pkg-config --cflags yaml-0.1)
+FPPFLAGS := $(shell pkg-config --cflags yaml-0.1) -DHAVE_FC_DO_CONCURRENT_LOCAL
 FFLAGS = $(FC_AUTO_R8) -Mnofma -i4 -gopt  -time -Mextend -byteswapio -Mflushz -Kieee -tp=zen3
 
 
@@ -39,8 +39,8 @@ else
 endif
 
 ifeq ($(OFFLOAD),1)
-  FFLAGS += -mp=gpu -gpu=cc80 -fopenmp -stdpar -Minfo=accel
-  CFLAGS += -mp=gpu -gpu=cc80
+  FFLAGS += -mp=gpu -gpu=cc80,mem:separate -stdpar=gpu -Minfo=accel
+  CFLAGS += -mp=gpu -gpu=cc80,mem:separate
   LDFLAGS += -mp=gpu -lmpi_gtl_cuda
 endif
 

--- a/build-utils/nvcc-cxx-wrap.sh
+++ b/build-utils/nvcc-cxx-wrap.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# CXX dispatch for the TIM GPU (offload) build.
+#
+# Any C++ TU that includes AMReX headers must be compiled by nvcc: nvc++ (the
+# Cray `CC` wrapper) reports "CUDA C++ compilation is unsupported in nvc++" and
+# leaves AMReX's __host__/__device__ undefined. We drive those with
+# `nvcc -ccbin CC` so nvcc handles the CUDA/device side while the Cray `CC`
+# wrapper remains the host compiler (keeping its automatic MPI/netCDF includes,
+# which tim_coms_infra.cpp needs). All non-AMReX C++ stays on plain CC.
+#
+# The AMReX-including TUs on dev/turbo-debug (keep in sync if more are ported):
+#   mom/cpp/mom_continuity_ppm.cpp, mom/cpp/turbotmp_mom_continuity_ppm_bridge.cpp,
+#   turbotmp/turbotmp_helper.cpp, tim/cpp/tim_profile.cpp, tim/cpp/tim_coms_infra.cpp
+#
+# mkmf invokes this as: <wrap> <CPPDEFS> <CPPFLAGS> <CXXFLAGS> <includes> -c -I.. file.cpp
+
+is_amrex=0
+for a in "$@"; do
+  case "$a" in
+    *mom_continuity_ppm.cpp|*turbotmp_mom_continuity_ppm_bridge.cpp|\
+*turbotmp_helper.cpp|*tim_profile.cpp|*tim_coms_infra.cpp)
+      is_amrex=1 ;;
+  esac
+done
+
+if [ "${is_amrex}" -eq 1 ]; then
+  # Drop nvc++-only flags nvcc would reject; keep -D, -I, -c, the source.
+  args=()
+  for x in "$@"; do
+    case "$x" in
+      --std=*|-cuda|-gpu=*|-mp=*|-Minfo=*|-Mnofma|-gopt|-time|-tp=*) ;;
+      *) args+=("$x") ;;
+    esac
+  done
+  exec nvcc -x cu -arch=sm_80 --extended-lambda --expt-relaxed-constexpr \
+       -std=c++17 -ccbin CC "${args[@]}"
+fi
+
+exec CC "$@"

--- a/build-utils/nvcc-cxx-wrap.sh
+++ b/build-utils/nvcc-cxx-wrap.sh
@@ -1,24 +1,13 @@
 #!/bin/bash
-# CXX dispatch for the TIM GPU (offload) build.
-#
-# Any C++ TU that includes AMReX headers must be compiled by nvcc: nvc++ (the
-# Cray `CC` wrapper) reports "CUDA C++ compilation is unsupported in nvc++" and
-# leaves AMReX's __host__/__device__ undefined. We drive those with
-# `nvcc -ccbin CC` so nvcc handles the CUDA/device side while the Cray `CC`
-# wrapper remains the host compiler (keeping its automatic MPI/netCDF includes,
-# which tim_coms_infra.cpp needs). All non-AMReX C++ stays on plain CC.
-#
-# The AMReX-including TUs on dev/turbo-debug (keep in sync if more are ported):
-#   mom/cpp/mom_continuity_ppm.cpp, mom/cpp/turbotmp_mom_continuity_ppm_bridge.cpp,
-#   turbotmp/turbotmp_helper.cpp, tim/cpp/tim_profile.cpp, tim/cpp/tim_coms_infra.cpp
-#
-# mkmf invokes this as: <wrap> <CPPDEFS> <CPPFLAGS> <CXXFLAGS> <includes> -c -I.. file.cpp
+# TEMPORARY: per-file CXX dispatch for the TIM GPU (offload) build, to be
+# removed by the build-system overhaul. AMReX TUs need nvcc (nvc++/Cray `CC`
+# can't compile CUDA); everything else stays on plain `CC`. This file will be
+# removed once the CMake build system is fully implemented.
 
 is_amrex=0
 for a in "$@"; do
   case "$a" in
-    *mom_continuity_ppm.cpp|*turbotmp_mom_continuity_ppm_bridge.cpp|\
-*turbotmp_helper.cpp|*tim_profile.cpp|*tim_coms_infra.cpp)
+    */mom/cpp/*.cpp|*turbotmp_helper.cpp|*tim_profile.cpp|*tim_coms_infra.cpp)
       is_amrex=1 ;;
   esac
 done

--- a/build.sh
+++ b/build.sh
@@ -264,7 +264,7 @@ if [[ "${INFRA}" == "TIM" ]]; then
     AMREX_BLD_PATH=$(pwd)/build              \
     CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}     \
     AMREX_INSTALL_PATH=${AMREX_INSTALL_PATH} \
-      make -j${JOBS} -C ${ROOTDIR}/build-utils/amrex-utils/ build_amrex
+      make -j${JOBS} OFFLOAD=${OFFLOAD} -C ${ROOTDIR}/build-utils/amrex-utils/ build_amrex
   fi
   AMREX_LINK_FLAGS="-L${AMREX_INSTALL_PATH}/lib -lamrex"
   AMREX_INCLUDE_FLAGS="-I${AMREX_INSTALL_PATH}/include"


### PR DESCRIPTION
- Add -DHAVE_FC_DO_CONCURRENT_LOCAL so MOM6 keeps reduce() clauses instead of serializing do-concurrent loops into single-thread GPU kernels.
- Switch offload to -gpu=cc80,mem:separate to disable managed memory (~5x slower on A100), 
- use -stdpar=gpu, and drop redundant -fopenmp.

Note that there are temporary changes in this PR that need to adjusted once the CMake changes are merged. So, this PR should probably be held off until the CMake PR gets merged.
