### PR TITLE
Add ParallelIO (PIO2) build support for the TIM backend

### DIFF
--- a/build-utils/makefile-templates/ncar-gnu.mk
+++ b/build-utils/makefile-templates/ncar-gnu.mk
@@ -23,7 +23,7 @@ FPPFLAGS :=
 FFLAGS := $(FC_AUTO_R8) -fconvert=big-endian -ffree-line-length-none -ffixed-line-length-none -fallow-argument-mismatch  -fallow-invalid-boz -fcray-pointer -fno-range-check
 CFLAGS := -std=gnu99 -DHAVE_GETTID
 
-CXXFLAGS := -std=c++17
+CXXFLAGS := -std=c++20
 
 # Compilation Mode-specific flags
 ifeq ($(CODECOV),1)

--- a/build-utils/makefile-templates/ncar-intel.mk
+++ b/build-utils/makefile-templates/ncar-intel.mk
@@ -27,7 +27,7 @@ CFLAGS := -qno-opt-dynamic-align -fp-model precise -std=gnu99  -no-fma -qopt-rep
 CFLAGS_REPRO= -O2 -debug minimal
 CFLAGS_DEBUG = -O0 -g
 
-CXXFLAGS := -std=c++17
+CXXFLAGS := -std=c++20 -fp-model precise -no-fma
 
 ifeq ($(DEBUG),1)
   FFLAGS += $(FFLAGS_DEBUG)

--- a/build-utils/makefile-templates/ncar-nvhpc.mk
+++ b/build-utils/makefile-templates/ncar-nvhpc.mk
@@ -26,7 +26,7 @@ FFLAGS = $(FC_AUTO_R8) -Mnofma -i4 -gopt  -time -Mextend -byteswapio -Mflushz -K
 CFLAGS = -gopt -time -Mnofma -DHAVE_GETTID
 CPPFLAGS := $(shell pkg-config --cflags yaml-0.1)
 
-CXXFLAGS := --std=c++17
+CXXFLAGS := --std=c++20 -Mnofma -Kieee
 
 # Get compile flags based on target macros.
 

--- a/build-utils/pio-utils/Makefile
+++ b/build-utils/pio-utils/Makefile
@@ -1,0 +1,35 @@
+include $(TEMPLATE)
+
+# Build ParallelIO (PIO2) from a pinned source tarball -- the container /
+# non-NCAR fallback when no parallelio module or PIO_INSTALL_PATH is
+# available. Mirrors build-utils/amrex-utils/Makefile, except the source is
+# downloaded rather than a submodule: the same pinned tag TIM's CMake
+# fallback (cmake/FindOrFetchPIO.cmake) fetches, so both build systems share
+# one source of truth. Note: the pio2_6_8 tag self-reports 2.6.6 (upstream
+# version-string lag, not a wrong pin).
+#
+# Only the C library (libpioc) is built: TIM's C++ I/O layer consumes just the
+# PIOc_* C API, so the Fortran library and GPTL timing are disabled to keep
+# the fallback build lean. NetCDF is discovered via nc-config; PnetCDF is not
+# required (PIO uses the netCDF backend).
+
+PIO_TAG = pio2_6_8
+PIO_TARBALL_URL = https://github.com/NCAR/ParallelIO/archive/refs/tags/$(PIO_TAG).tar.gz
+PIO_SRC_DIR = $(PIO_SRC_PATH)/ParallelIO-$(PIO_TAG)
+
+build_pio:
+	test -f $(PIO_SRC_DIR)/CMakeLists.txt || \
+		( mkdir -p $(PIO_SRC_PATH) && \
+		  curl -fsSL $(PIO_TARBALL_URL) | tar xz -C $(PIO_SRC_PATH) )
+	cmake -S $(PIO_SRC_DIR) -B ${PIO_BLD_PATH}           \
+		--install-prefix ${PIO_INSTALL_PATH}             \
+		-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}           \
+		-DPIO_ENABLE_FORTRAN=OFF                         \
+		-DPIO_ENABLE_TIMING=OFF                          \
+		-DPIO_ENABLE_EXAMPLES=OFF                        \
+		-DPIO_ENABLE_LOGGING=OFF                         \
+		-DWITH_PNETCDF=OFF                               \
+		-DNetCDF_C_PATH=$(shell nc-config --prefix)      \
+		-DCMAKE_C_COMPILER=$(shell which $(CC))       && \
+	cmake --build ${PIO_BLD_PATH} -j ${JOBS}          && \
+	cmake --install ${PIO_BLD_PATH}

--- a/build-utils/pio-utils/Makefile
+++ b/build-utils/pio-utils/Makefile
@@ -3,15 +3,20 @@ include $(TEMPLATE)
 # Build ParallelIO (PIO2) from a pinned source tarball -- the container /
 # non-NCAR fallback when no parallelio module or PIO_INSTALL_PATH is
 # available. Mirrors build-utils/amrex-utils/Makefile, except the source is
-# downloaded rather than a submodule: the same pinned tag TIM's CMake
-# fallback (cmake/FindOrFetchPIO.cmake) fetches, so both build systems share
-# one source of truth. Note: the pio2_6_8 tag self-reports 2.6.6 (upstream
-# version-string lag, not a wrong pin).
+# downloaded rather than a submodule.
 #
 # Only the C library (libpioc) is built: TIM's C++ I/O layer consumes just the
 # PIOc_* C API, so the Fortran library and GPTL timing are disabled to keep
-# the fallback build lean. NetCDF is discovered via nc-config; PnetCDF is not
-# required (PIO uses the netCDF backend).
+# the fallback build lean. NetCDF is discovered via nc-config.
+#
+# NOTICE: this fallback is built without PnetCDF (WITH_PNETCDF=OFF), so the
+# resulting libpioc does not offer the PNETCDF iotype -- only the netCDF-based
+# iotypes. This is deliberate: the fallback serves bare environments where
+# PnetCDF is not guaranteed to exist, and turning WITH_PNETCDF on would make
+# PIO's configure fail on exactly those machines. Prebuilt PIO installs (the
+# Derecho parallelio module, the CI container image) come with PnetCDF enabled
+# and are always preferred by build.sh, so this limitation only applies when
+# no prebuilt PIO is found.
 
 PIO_TAG = pio2_6_8
 PIO_TARBALL_URL = https://github.com/NCAR/ParallelIO/archive/refs/tags/$(PIO_TAG).tar.gz

--- a/build.sh
+++ b/build.sh
@@ -248,9 +248,16 @@ MOM6_src_files=${MOM_ROOT}/{config_src/memory/${MEMORY_MODE},config_src/drivers/
 
 # 0) Build AMReX if needed; also set -D_TIM for MOM6 build
 if [[ "${INFRA}" == "TIM" ]]; then
-  # ParallelIO (PIO2) dependency for TIM.
+  # ParallelIO (PIO2) dependency for TIM. Resolution order: caller-provided
+  # PIO_INSTALL_PATH, the Derecho parallelio module (NCAR_ROOT_PARALLELIO),
+  # a prebuilt install advertised via PIO (set by both the CI containers and
+  # the Derecho module), and finally a download-and-build of the pinned
+  # source tarball.
   if [[ -z "${PIO_INSTALL_PATH}" && -n "${NCAR_ROOT_PARALLELIO}" ]]; then
     PIO_INSTALL_PATH="${NCAR_ROOT_PARALLELIO}"
+  fi
+  if [[ -z "${PIO_INSTALL_PATH}" && -n "${PIO}" ]]; then
+    PIO_INSTALL_PATH="${PIO}"
   fi
   if [[ -z "${PIO_INSTALL_PATH}" ]]; then
     echo "Path to ParallelIO not declared.  Downloading and building libpioc."

--- a/build.sh
+++ b/build.sh
@@ -228,13 +228,13 @@ if [ "$MACHINE" == "ncar" ]; then
     module reset
     case $COMPILER in
       "intel" )
-        module load ncarenv/25.10 intel/2025.2.1 ncarcompilers/1.1.0 hdf5/1.14.6 netcdf/4.9.3 cmake
+        module load ncarenv/25.10 intel/2025.2.1 ncarcompilers/1.1.0 hdf5/1.14.6 netcdf/4.9.3 parallelio/2.6.8 cmake
         ;;
       "gnu" )
-        module load ncarenv/25.10 gcc/14.3.0 ncarcompilers/1.1.0 hdf5/1.14.6 netcdf/4.9.3 cmake
+        module load ncarenv/25.10 gcc/14.3.0 ncarcompilers/1.1.0 hdf5/1.14.6 netcdf/4.9.3 parallelio/2.6.8 cmake
         ;;
       "nvhpc" )
-        module load ncarenv/25.10 cuda/12.9.0 hdf5/1.14.6 nvhpc/25.9 ncarcompilers/1.1.0 netcdf/4.9.3 cmake
+        module load ncarenv/25.10 cuda/12.9.0 hdf5/1.14.6 nvhpc/25.9 ncarcompilers/1.1.0 netcdf/4.9.3 parallelio/2.6.8 cmake
         ;;
       *)
         echo "Not loading any special modules for ${COMPILER}"
@@ -248,6 +248,19 @@ MOM6_src_files=${MOM_ROOT}/{config_src/memory/${MEMORY_MODE},config_src/drivers/
 
 # 0) Build AMReX if needed; also set -D_TIM for MOM6 build
 if [[ "${INFRA}" == "TIM" ]]; then
+  # ParallelIO (PIO2) dependency for TIM.
+  if [[ -z "${PIO_INSTALL_PATH}" && -n "${NCAR_ROOT_PARALLELIO}" ]]; then
+    PIO_INSTALL_PATH="${NCAR_ROOT_PARALLELIO}"
+  fi
+  if [[ -n "${PIO_INSTALL_PATH}" ]]; then
+    PIO_INCLUDE_FLAGS="-I${PIO_INSTALL_PATH}/include"
+    PIO_LINK_FLAGS="-L${PIO_INSTALL_PATH}/lib -lpioc"
+  else
+    echo "ERROR: ParallelIO not found. The TIM backend requires PIO2."
+    echo "       Load the parallelio module or set PIO_INSTALL_PATH."
+    exit 1
+  fi
+
   # Check if AMREX_INSTALL_PATH was provided or if need to build from submodule first.
   if [[ -z "${AMREX_INSTALL_PATH}" ]]; then
     echo "Path to AMReX not declared.  Building AMReX through submodule."
@@ -296,8 +309,8 @@ fi
 
 # 1) Build Underlying Infrastructure Library
 if [[ "${INFRA}" == "TIM" ]]; then
-  INFRA_INCLUDE_FLAGS="${AMREX_INCLUDE_FLAGS}"
-  INFRA_LINKING_FLAGS="${AMREX_LINK_FLAGS}"
+  INFRA_INCLUDE_FLAGS="${AMREX_INCLUDE_FLAGS} ${PIO_INCLUDE_FLAGS}"
+  INFRA_LINKING_FLAGS="${AMREX_LINK_FLAGS} ${PIO_LINK_FLAGS}"
 fi
 
 cd ${BLD_PATH}
@@ -311,9 +324,9 @@ make -j${JOBS} DEBUG=${DEBUG} CODECOV=${CODECOV} OFFLOAD=${OFFLOAD} lib${INFRA}.
 LINKING_FLAGS="-L../MOM6-infra -linfra-${INFRA} -L../${INFRA} -l${INFRA}"
 INCLUDE_OPTS="-I../${INFRA} -I../MOM6-infra"
 if [[ "${INFRA}" == "TIM" ]]; then
-  INCLUDE_OPTS="${INCLUDE_OPTS} ${AMREX_INCLUDE_FLAGS}"
+  INCLUDE_OPTS="${INCLUDE_OPTS} ${AMREX_INCLUDE_FLAGS} ${PIO_INCLUDE_FLAGS}"
   # -lstdc++ link flag needed for older ocmpilers (especially non llvm based ones)
-  LINKING_FLAGS="${LINKING_FLAGS} -lstdc++ ${AMREX_LINK_FLAGS}"
+  LINKING_FLAGS="${LINKING_FLAGS} -lstdc++ ${AMREX_LINK_FLAGS} ${PIO_LINK_FLAGS}"
 fi
 
 # 2) Build MOM6 infra

--- a/build.sh
+++ b/build.sh
@@ -276,8 +276,13 @@ if [[ "${INFRA}" == "TIM" ]]; then
     PIO_INSTALL_PATH=${PIO_INSTALL_PATH}   \
       make -j${JOBS} -C ${ROOTDIR}/build-utils/pio-utils/ build_pio
   fi
+  # libpioc may live in lib or lib64 depending on the install layout.
+  PIO_LIB_DIR="lib"
+  if [[ ! -e "${PIO_INSTALL_PATH}/lib/libpioc.a" && ! -e "${PIO_INSTALL_PATH}/lib/libpioc.so" && -d "${PIO_INSTALL_PATH}/lib64" ]]; then
+    PIO_LIB_DIR="lib64"
+  fi
   PIO_INCLUDE_FLAGS="-I${PIO_INSTALL_PATH}/include"
-  PIO_LINK_FLAGS="-L${PIO_INSTALL_PATH}/lib -lpioc"
+  PIO_LINK_FLAGS="-L${PIO_INSTALL_PATH}/${PIO_LIB_DIR} -lpioc"
 
   # Check if AMREX_INSTALL_PATH was provided or if need to build from submodule first.
   if [[ -z "${AMREX_INSTALL_PATH}" ]]; then
@@ -343,7 +348,7 @@ LINKING_FLAGS="-L../MOM6-infra -linfra-${INFRA} -L../${INFRA} -l${INFRA}"
 INCLUDE_OPTS="-I../${INFRA} -I../MOM6-infra"
 if [[ "${INFRA}" == "TIM" ]]; then
   INCLUDE_OPTS="${INCLUDE_OPTS} ${AMREX_INCLUDE_FLAGS} ${PIO_INCLUDE_FLAGS}"
-  # -lstdc++ link flag needed for older ocmpilers (especially non llvm based ones)
+  # -lstdc++ link flag needed for older compilers (especially non llvm based ones)
   LINKING_FLAGS="${LINKING_FLAGS} -lstdc++ ${AMREX_LINK_FLAGS} ${PIO_LINK_FLAGS}"
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -252,14 +252,25 @@ if [[ "${INFRA}" == "TIM" ]]; then
   if [[ -z "${PIO_INSTALL_PATH}" && -n "${NCAR_ROOT_PARALLELIO}" ]]; then
     PIO_INSTALL_PATH="${NCAR_ROOT_PARALLELIO}"
   fi
-  if [[ -n "${PIO_INSTALL_PATH}" ]]; then
-    PIO_INCLUDE_FLAGS="-I${PIO_INSTALL_PATH}/include"
-    PIO_LINK_FLAGS="-L${PIO_INSTALL_PATH}/lib -lpioc"
-  else
-    echo "ERROR: ParallelIO not found. The TIM backend requires PIO2."
-    echo "       Load the parallelio module or set PIO_INSTALL_PATH."
-    exit 1
+  if [[ -z "${PIO_INSTALL_PATH}" ]]; then
+    echo "Path to ParallelIO not declared.  Downloading and building libpioc."
+    cd "${BLD_PATH}"
+    mkdir -p parallelio
+    cd parallelio
+
+    PIO_INSTALL_PATH="$(pwd)/install"
+
+    # Redeclaring variables needed because they are not exported
+    TEMPLATE=${TEMPLATE}                   \
+    JOBS=${JOBS}                           \
+    PIO_SRC_PATH=$(pwd)/src                \
+    PIO_BLD_PATH=$(pwd)/build              \
+    CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}   \
+    PIO_INSTALL_PATH=${PIO_INSTALL_PATH}   \
+      make -j${JOBS} -C ${ROOTDIR}/build-utils/pio-utils/ build_pio
   fi
+  PIO_INCLUDE_FLAGS="-I${PIO_INSTALL_PATH}/include"
+  PIO_LINK_FLAGS="-L${PIO_INSTALL_PATH}/lib -lpioc"
 
   # Check if AMREX_INSTALL_PATH was provided or if need to build from submodule first.
   if [[ -z "${AMREX_INSTALL_PATH}" ]]; then

--- a/scripts/setup_environment/derecho_cpu_gcc_openmpi.sh
+++ b/scripts/setup_environment/derecho_cpu_gcc_openmpi.sh
@@ -2,7 +2,7 @@
 # scripts/setup_environment/derecho_cpu_gcc_openmpi.sh
 #
 # SOURCED.  Stage-1 (environment setup) toolchain step ONLY: loads Derecho's
-# CPU / gcc / OpenMPI toolchain via Lmod (compiler, CMake, MPI, NetCDF).  It does
+# CPU / gcc / OpenMPI toolchain via Lmod (compiler, CMake, MPI, NetCDF, ParallelIO).
 # NOT build any dependencies and has no side effects beyond preparing the shell --
 # the upstream submodule deps (AMReX/pFUnit = Tier 1.5; FMS/TIM = Tier 2) are built
 # explicitly by the caller via the turbo_build_* wrappers in scripts/lib/common.sh.
@@ -12,7 +12,7 @@
 
 # --- Toolchain (Stage 1 env setup; Tier 1) -----------------------------
 module purge
-module load gcc cmake openmpi netcdf #pfunit
+module load gcc cmake openmpi netcdf parallelio #pfunit
 
 # Temporary fix so the correct C++ standard library is picked up for TIM, which
 # is built with gcc 14.3.0 on Derecho while the default compiler is still older.

--- a/spack/spack.yaml
+++ b/spack/spack.yaml
@@ -5,6 +5,7 @@ spack:
     - gmake
     - mpi
     - netcdf-fortran
+    - parallelio
     - pfunit +mpi
     - amrex +fortran
   view: true


### PR DESCRIPTION
Introduces ParallelIO (PIO2) dependency into both legacy and new turbo-stack build systems so TIM's forthcoming C++ I/O layer can link libpioc. No TIM source consumes PIO yet, so this doesn't change any built executable yet.

Changes:

- scripts/setup_environment/derecho_cpu_gcc_openmpi.sh: load the parallelio module (ships PIOConfig.cmake), so TIM's find_package(PIO) resolves when build_dep builds TIM.
- spack/spack.yaml: add the parallelio spec so the spack environment provides PIO.

Legacy mkmf build.sh:

- build.sh: add parallelio/2.6.8 to the intel/gnu/nvhpc module loads; for the TIM backend, resolve PIO_INCLUDE_FLAGS/PIO_LINK_FLAGS (-lpioc) from NCAR_ROOT_PARALLELIO (or a caller-provided PIO_INSTALL_PATH), threaded into the libTIM and MOM6 link lines like AMREX_*. When neither is available (e.g. CI containers), the pinned PIO source tarball is downloaded and built automatically.
- build-utils/pio-utils/Makefile: the download+build recipe (C library only; Fortran/GPTL/PnetCDF off). 
- build-utils/makefile-templates/ncar-{intel,gnu,nvhpc}.mk: bump CXXFLAGS to C++20 and add fp-model  -no-fma for intel,-Mnofma -Kieee for nvhpc) to match the existing Fortran/C floating-point settings. (This is a bit out-of-scope, so I'm happy to revert.)