### PR TITLE
248 feature turbo specific ci containers for the cmake build system

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -166,9 +166,28 @@ src/amrex_mini_app/ (C++ / CMake — separate build)
 
 ## CI/CD
 
-GitHub Actions workflows (`.github/workflows/`) test against a matrix of compilers (oneapi, gcc14, nvhpc, clang) and MPI libraries (MPICH, OpenMPI) on both `ubuntu-latest` and the custom `gha-runner-turbo` runner.
+GitHub Actions workflows (`.github/workflows/`) cover the two build systems in
+separate lanes, in different containers:
 
-Containers used: `ncarcisl/cisldev-x86_64-almalinux9-[compiler]-[mpi]`; activated via `/container/config_env.sh`.
+| Lane | Build system | Container |
+|---|---|---|
+| `build-tests*.yaml`, `unit-tests.yaml`, `matrix-compiler-smoketest.yaml`, `code-coverage-reports.yaml` | legacy mkmf `./build.sh` | `ncarcisl/cisldev-x86_64-almalinux9-[compiler]-[mpi]`, activated via `/container/config_env.sh` |
+| `turbo-cmake-container-tests.yaml` | **CMake** (`scripts/build_local_with_spack_env.sh`, spack flavor) | `ghcr.io/turbo-esm/turbo-stack/turbo-ci:gcc-openmpi`, built by `build-turbo-ci-container.yaml` from `docker/Dockerfile.turbo-ci` |
+
+The legacy lane runs a matrix of compilers (oneapi, gcc14, nvhpc, clang) and MPI
+libraries (MPICH, OpenMPI) across `ubuntu-latest` and the custom
+`gha-runner-turbo` runner. The CMake lane is currently gcc + OpenMPI on
+`ubuntu-latest` only, for both infra backends (TIM, FMS2).
+
+The `turbo-ci` image bakes the repo's `spack/spack.yaml` environment
+(`turbo_stack`) so CI does not rebuild dependencies each run. It is **private**,
+and a `spack.yaml` change does not reach CI until the producer workflow is
+re-run manually (`gh workflow run build-turbo-ci-container.yaml`) — see
+[`docker/README.md`](../docker/README.md).
+
+Branches that trigger CI: `main` for the CMake lane; `main` plus the legacy
+`ci-tests` / `container-ci` branches for the mkmf lane. Any workflow can also be
+run against an arbitrary branch with `gh workflow run <file> --ref <branch>`.
 
 Clang-format (Google style, C++20, 120-char limit) is enforced on PRs and auto-applied on pushes to `main`.
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+# docker/Dockerfile.turbo-ci only needs spack/ from the build context.
+# Exclude everything heavy so the context stays tiny and deterministic
+# (submodules alone — AMReX, MOM6, pFUnit — are gigabytes when initialized).
+.git
+submodules/
+build/
+deps/
+bin/
+dev-utils/
+*.log

--- a/.github/workflows/build-turbo-ci-container.yaml
+++ b/.github/workflows/build-turbo-ci-container.yaml
@@ -14,6 +14,21 @@ name: Build turbo-stack CI container
 
 on:
   workflow_dispatch:
+  # --- TEMPORARY: remove before merging PR #248 into main ----------------------
+  # workflow_dispatch is unavailable until this workflow lives on the default
+  # branch, so to validate the image build from this feature branch we trigger on
+  # push. Scoped to this branch AND to generator inputs only, so the (expensive)
+  # image rebuilds just when the recipe changes -- not on every commit.
+  push:
+    branches:
+      - 248-feature-turbo-specific-ci-containers-for-the-cmake-build-system
+    paths:
+      - docker/Dockerfile.turbo-ci
+      - .dockerignore
+      - spack/spack.yaml
+      - spack/create_spack_environment.sh
+      - .github/workflows/build-turbo-ci-container.yaml
+  # --- end TEMPORARY ----------------------------------------------------------
 
 permissions:
   contents: read

--- a/.github/workflows/build-turbo-ci-container.yaml
+++ b/.github/workflows/build-turbo-ci-container.yaml
@@ -33,6 +33,14 @@ permissions:
   contents: read
   packages: write
 
+# One image build at a time. Two concurrent dispatches would race to push the same
+# mutable `gcc-openmpi` tag and would both export mode=max to the shared
+# :buildcache tag. Queue instead of cancel: a nearly-finished 1 h build should not
+# be thrown away by a second dispatch.
+concurrency:
+  group: turbo-ci-image
+  cancel-in-progress: false
+
 env:
   # Single source of truth for the image ref. Spelled out literally rather than
   # derived from ${{ github.repository }}, which is TURBO-ESM/turbo-stack --

--- a/.github/workflows/build-turbo-ci-container.yaml
+++ b/.github/workflows/build-turbo-ci-container.yaml
@@ -5,23 +5,15 @@
 # (cmake, openmpi, netcdf, pfunit, amrex) on every run. It is consumed by
 # .github/workflows/turbo-cmake-container-tests.yaml.
 #
-# This build is expensive (Spack compiles the toolchain deps from source), so it
-# runs only on demand, on a weekly schedule, and when the recipe changes -- NOT
-# on every push. Layer caching (type=gha) makes unchanged rebuilds cheap.
+# This build is expensive (Spack compiles the toolchain deps from source), so for
+# now it is triggered manually only (workflow_dispatch). Layer caching (type=gha)
+# keeps rebuilds cheap. To automate later, re-add a `push` trigger on the recipe
+# paths (spack/spack.yaml, spack/create_spack_environment.sh,
+# docker/Dockerfile.turbo-ci) and/or a weekly `schedule` for base-image updates.
 name: Build turbo-stack CI container
 
 on:
   workflow_dispatch:
-  push:
-    branches: [main]
-    paths:
-      - 'spack/spack.yaml'
-      - 'spack/create_spack_environment.sh'
-      - 'docker/Dockerfile.turbo-ci'
-      - '.dockerignore'
-      - '.github/workflows/build-turbo-ci-container.yaml'
-  schedule:
-    - cron: '0 6 * * 1'   # Mondays 06:00 UTC: pick up base-image / security updates
 
 permissions:
   contents: read

--- a/.github/workflows/build-turbo-ci-container.yaml
+++ b/.github/workflows/build-turbo-ci-container.yaml
@@ -5,39 +5,49 @@
 # (cmake, openmpi, netcdf, pfunit, amrex) on every run. It is consumed by
 # .github/workflows/turbo-cmake-container-tests.yaml.
 #
-# This build is expensive (Spack compiles the toolchain deps from source), so for
-# now it is triggered manually only (workflow_dispatch). Layer caching (a GHCR
-# registry cache tag, turbo-ci:buildcache) keeps rebuilds cheap. To automate
-# later, re-add a `push` trigger on the recipe
-# paths (spack/spack.yaml, spack/create_spack_environment.sh,
-# docker/Dockerfile.turbo-ci) and/or a weekly `schedule` for base-image updates.
+# This build is expensive -- ~1 hour, because Spack compiles the dependency stack
+# from source -- so it is manual only: no push or pull_request trigger. A merge
+# should never block on an image rebuild. Layer caching (a GHCR registry cache
+# tag, turbo-ci:buildcache) keeps incremental rebuilds cheap.
+#
+# Rebuild after changing a generator input (spack/spack.yaml,
+# spack/create_spack_environment.sh, docker/Dockerfile.turbo-ci): Actions ->
+# "Build turbo-stack CI container" -> Run workflow, or
+#     gh workflow run build-turbo-ci-container.yaml
+#
+# To validate a recipe change BEFORE merging it, dispatch against your branch --
+# the run uses that branch's Dockerfile and spack.yaml:
+#     gh workflow run build-turbo-ci-container.yaml --ref <your-branch>
+# That is safe: the mutable `gcc-openmpi` tag the consumer pulls is only
+# published from the default branch (see the tag list below), so a branch build
+# cannot hand the team an unvalidated image.
+#
+# Deferred on purpose: a weekly `schedule` to pick up base-image/CVE updates, and
+# a broader compiler matrix (clang / oneapi).
 name: Build turbo-stack CI container
 
 on:
   workflow_dispatch:
-  # --- TEMPORARY: remove before merging PR #248 into main ----------------------
-  # workflow_dispatch is unavailable until this workflow lives on the default
-  # branch, so to validate the image build from this feature branch we trigger on
-  # push. Scoped to this branch AND to generator inputs only, so the (expensive)
-  # image rebuilds just when the recipe changes -- not on every commit.
-  push:
-    branches:
-      - 248-feature-turbo-specific-ci-containers-for-the-cmake-build-system
-    paths:
-      - docker/Dockerfile.turbo-ci
-      - .dockerignore
-      - spack/spack.yaml
-      - spack/create_spack_environment.sh
-      - .github/workflows/build-turbo-ci-container.yaml
-  # --- end TEMPORARY ----------------------------------------------------------
 
 permissions:
   contents: read
   packages: write
 
+env:
+  # Single source of truth for the image ref. Spelled out literally rather than
+  # derived from ${{ github.repository }}, which is TURBO-ESM/turbo-stack --
+  # GHCR requires an all-lowercase path. The consumer
+  # (turbo-cmake-container-tests.yaml) repeats this literal because the `env`
+  # context is not available in `jobs.<job_id>.container.image`; keep the two in
+  # sync.
+  IMAGE: ghcr.io/turbo-esm/turbo-stack/turbo-ci
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    # A full from-source Spack build is ~1 h; anything past 3 h means a hung
+    # fetch or compile, so fail rather than burn the 6 h default.
+    timeout-minutes: 180
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -57,10 +67,15 @@ jobs:
         id: meta
         uses: docker/metadata-action@v6
         with:
-          # metadata-action lowercases the image name for GHCR automatically.
-          images: ghcr.io/${{ github.repository }}/turbo-ci
+          images: ${{ env.IMAGE }}
+          # `gcc-openmpi` is the mutable tag the consumer pulls. It is published
+          # ONLY from the default branch, so dispatching this workflow against a
+          # feature branch validates the recipe (the expensive, likely-to-fail
+          # part) without handing the team an unvalidated image.
+          # The sha-suffixed tag is always published: it is the immutable ref to
+          # point the consumer at when bisecting an image regression.
           tags: |
-            type=raw,value=gcc-openmpi
+            type=raw,value=gcc-openmpi,enable={{is_default_branch}}
             type=sha,prefix=gcc-openmpi-,format=short
 
       - name: Build and push
@@ -74,5 +89,5 @@ jobs:
           # Registry-backed layer cache stored as a :buildcache tag in GHCR.
           # The GitHub Actions cache backend (type=gha) returns `not_found` on
           # export here and aborts the in-flight image push, so it is unusable.
-          cache-from: type=registry,ref=ghcr.io/turbo-esm/turbo-stack/turbo-ci:buildcache
-          cache-to: type=registry,ref=ghcr.io/turbo-esm/turbo-stack/turbo-ci:buildcache,mode=max
+          cache-from: type=registry,ref=${{ env.IMAGE }}:buildcache
+          cache-to: type=registry,ref=${{ env.IMAGE }}:buildcache,mode=max

--- a/.github/workflows/build-turbo-ci-container.yaml
+++ b/.github/workflows/build-turbo-ci-container.yaml
@@ -24,14 +24,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         # No submodules: the image build only needs spack/ (see .dockerignore).
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -39,7 +39,7 @@ jobs:
 
       - name: Compute image tags
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           # metadata-action lowercases the image name for GHCR automatically.
           images: ghcr.io/${{ github.repository }}/turbo-ci
@@ -48,7 +48,7 @@ jobs:
             type=sha,prefix=gcc-openmpi-,format=short
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/Dockerfile.turbo-ci

--- a/.github/workflows/build-turbo-ci-container.yaml
+++ b/.github/workflows/build-turbo-ci-container.yaml
@@ -2,8 +2,8 @@
 #
 # The image bakes the repo's own Spack environment (spack/spack.yaml, env name
 # "turbo_stack") so that CI does not rebuild Tier-1/Tier-1.5 dependencies
-# (cmake, openmpi, netcdf, pfunit, amrex) on every run. It is consumed by
-# .github/workflows/turbo-cmake-container-tests.yaml.
+# (cmake, openmpi, netcdf, parallelio, pfunit, amrex) on every run. It is
+# consumed by .github/workflows/turbo-cmake-container-tests.yaml.
 #
 # This build is expensive -- ~1 hour, because Spack compiles the dependency stack
 # from source -- so it is manual only: no push or pull_request trigger. A merge

--- a/.github/workflows/build-turbo-ci-container.yaml
+++ b/.github/workflows/build-turbo-ci-container.yaml
@@ -1,0 +1,67 @@
+# Producer: build the turbo-stack CI base image and push it to GHCR.
+#
+# The image bakes the repo's own Spack environment (spack/spack.yaml, env name
+# "turbo_stack") so that CI does not rebuild Tier-1/Tier-1.5 dependencies
+# (cmake, openmpi, netcdf, pfunit, amrex) on every run. It is consumed by
+# .github/workflows/turbo-cmake-container-tests.yaml.
+#
+# This build is expensive (Spack compiles the toolchain deps from source), so it
+# runs only on demand, on a weekly schedule, and when the recipe changes -- NOT
+# on every push. Layer caching (type=gha) makes unchanged rebuilds cheap.
+name: Build turbo-stack CI container
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'spack/spack.yaml'
+      - 'spack/create_spack_environment.sh'
+      - 'docker/Dockerfile.turbo-ci'
+      - '.dockerignore'
+      - '.github/workflows/build-turbo-ci-container.yaml'
+  schedule:
+    - cron: '0 6 * * 1'   # Mondays 06:00 UTC: pick up base-image / security updates
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        # No submodules: the image build only needs spack/ (see .dockerignore).
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          # metadata-action lowercases the image name for GHCR automatically.
+          images: ghcr.io/${{ github.repository }}/turbo-ci
+          tags: |
+            type=raw,value=gcc-openmpi
+            type=sha,prefix=gcc-openmpi-,format=short
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.turbo-ci
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build-turbo-ci-container.yaml
+++ b/.github/workflows/build-turbo-ci-container.yaml
@@ -6,8 +6,9 @@
 # .github/workflows/turbo-cmake-container-tests.yaml.
 #
 # This build is expensive (Spack compiles the toolchain deps from source), so for
-# now it is triggered manually only (workflow_dispatch). Layer caching (type=gha)
-# keeps rebuilds cheap. To automate later, re-add a `push` trigger on the recipe
+# now it is triggered manually only (workflow_dispatch). Layer caching (a GHCR
+# registry cache tag, turbo-ci:buildcache) keeps rebuilds cheap. To automate
+# later, re-add a `push` trigger on the recipe
 # paths (spack/spack.yaml, spack/create_spack_environment.sh,
 # docker/Dockerfile.turbo-ci) and/or a weekly `schedule` for base-image updates.
 name: Build turbo-stack CI container
@@ -70,5 +71,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Registry-backed layer cache stored as a :buildcache tag in GHCR.
+          # The GitHub Actions cache backend (type=gha) returns `not_found` on
+          # export here and aborts the in-flight image push, so it is unusable.
+          cache-from: type=registry,ref=ghcr.io/turbo-esm/turbo-stack/turbo-ci:buildcache
+          cache-to: type=registry,ref=ghcr.io/turbo-esm/turbo-stack/turbo-ci:buildcache,mode=max

--- a/.github/workflows/turbo-cmake-container-tests.yaml
+++ b/.github/workflows/turbo-cmake-container-tests.yaml
@@ -8,18 +8,17 @@
 # ctest (unit tests are opt-in via --tests; ctest uses --no-tests=error).
 name: turbo-stack CMake build (container)
 
+# Only main + PRs. The sibling workflows (build-tests.yaml, unit-tests.yaml) also
+# list the ci-tests/container-ci branches; that is not needed here -- to exercise
+# this workflow on a feature branch, dispatch it against that branch and the run
+# uses that branch's file:
+#     gh workflow run turbo-cmake-container-tests.yaml --ref <your-branch>
 on:
   workflow_dispatch:
   push:
-    branches:
-      - main
-      # TEMPORARY (remove before merging PR #248): run the consumer on this
-      # feature branch to validate both backends against the freshly built
-      # image. workflow_dispatch is unavailable until this workflow is on the
-      # default branch, so a branch push is the only way to exercise it here.
-      - 248-feature-turbo-specific-ci-containers-for-the-cmake-build-system
+    branches: ["main"]
   pull_request:
-    branches: [main]
+    branches: ["main"]
 
 permissions:
   contents: read
@@ -29,13 +28,19 @@ jobs:
   build-test:
     name: build+test (${{ matrix.infra }})
     runs-on: ubuntu-latest
+    # ~9 min when healthy. A deadlocked MPI test would otherwise hang for the 6 h
+    # default.
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
         infra: [TIM, FMS2]
     container:
-      # Lowercased github.repository (GHCR requires lowercase). Repo is
-      # TURBO-ESM/turbo-stack, so the image is under turbo-esm/turbo-stack.
+      # Must match `env.IMAGE` in build-turbo-ci-container.yaml. Hard-coded rather
+      # than derived: GHCR requires an all-lowercase path (the repo is
+      # TURBO-ESM/turbo-stack), and the `env` context is not available here.
+      # `gcc-openmpi` is a mutable tag -- a producer rebuild changes what CI
+      # tests. Pin a `gcc-openmpi-<sha>` tag to bisect an image regression.
       image: ghcr.io/turbo-esm/turbo-stack/turbo-ci:gcc-openmpi
       credentials:
         username: ${{ github.actor }}
@@ -67,4 +72,4 @@ jobs:
       - name: Build + test turbo-stack (${{ matrix.infra }})
         # SPACK_ROOT comes from the image (ENV). This one command runs the whole
         # Spack-flavor pipeline: activate env -> build backend -> cmake -> ctest.
-        run: scripts/build_local_with_spack_env.sh --infra ${{ matrix.infra }} --tests #--build_dir build_turbo_stack_with_${{ matrix.infra }}
+        run: scripts/build_local_with_spack_env.sh --infra ${{ matrix.infra }} --tests

--- a/.github/workflows/turbo-cmake-container-tests.yaml
+++ b/.github/workflows/turbo-cmake-container-tests.yaml
@@ -11,7 +11,13 @@ name: turbo-stack CMake build (container)
 on:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches:
+      - main
+      # TEMPORARY (remove before merging PR #248): run the consumer on this
+      # feature branch to validate both backends against the freshly built
+      # image. workflow_dispatch is unavailable until this workflow is on the
+      # default branch, so a branch push is the only way to exercise it here.
+      - 248-feature-turbo-specific-ci-containers-for-the-cmake-build-system
   pull_request:
     branches: [main]
 
@@ -55,4 +61,4 @@ jobs:
       - name: Build + test turbo-stack (${{ matrix.infra }})
         # SPACK_ROOT comes from the image (ENV). This one command runs the whole
         # Spack-flavor pipeline: activate env -> build backend -> cmake -> ctest.
-        run: scripts/build_local_with_spack_env.sh --infra ${{ matrix.infra }} --tests
+        run: scripts/build_local_with_spack_env.sh --infra ${{ matrix.infra }} --tests #--build_dir build_turbo_stack_with_${{ matrix.infra }}

--- a/.github/workflows/turbo-cmake-container-tests.yaml
+++ b/.github/workflows/turbo-cmake-container-tests.yaml
@@ -44,6 +44,12 @@ jobs:
       # Hosted ubuntu-latest runners have ~4 cores; parallelize every cmake --build
       # in the pipeline (FMS/TIM deps + turbo-stack) without per-call flags.
       CMAKE_BUILD_PARALLEL_LEVEL: "4"
+      # The pFUnit suites launch `mpirun -np 4` (@test(npes=[1,2,4])), but PRRTE
+      # (OpenMPI 5) sees only ~2 slots (physical cores) on the hosted runner and
+      # refuses to launch 4 procs ("not enough slots"). Let it oversubscribe so
+      # the MPI tests run in CI. This is a runner constraint, so it lives here
+      # rather than baked into the image (harmless on many-core machines too).
+      PRTE_MCA_rmaps_default_mapping_policy: ":oversubscribe"
     steps:
       - name: Checkout (with submodules)
         uses: actions/checkout@v7

--- a/.github/workflows/turbo-cmake-container-tests.yaml
+++ b/.github/workflows/turbo-cmake-container-tests.yaml
@@ -1,0 +1,58 @@
+# Consumer: exercise the NEW CMake build system inside the turbo-stack CI image.
+#
+# Runs scripts/build_local_with_spack_env.sh for both infra backends (TIM, FMS2)
+# inside ghcr.io/.../turbo-ci (built by build-turbo-ci-container.yaml). The image
+# already has SPACK_ROOT set and the "turbo_stack" Spack env installed, so the
+# script activates that env (no reinstall), builds only the selected Tier-2
+# backend from its submodule, then cmake-configures/builds turbo-stack and runs
+# ctest (unit tests are opt-in via --tests; ctest uses --no-tests=error).
+name: turbo-stack CMake build (container)
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  build-test:
+    name: build+test (${{ matrix.infra }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        infra: [TIM, FMS2]
+    container:
+      # Lowercased github.repository (GHCR requires lowercase). Repo is
+      # TURBO-ESM/turbo-stack, so the image is under turbo-esm/turbo-stack.
+      image: ghcr.io/turbo-esm/turbo-stack/turbo-ci:gcc-openmpi
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    env:
+      # Hosted ubuntu-latest runners have ~4 cores; parallelize every cmake --build
+      # in the pipeline (FMS/TIM deps + turbo-stack) without per-call flags.
+      CMAKE_BUILD_PARALLEL_LEVEL: "4"
+    steps:
+      - name: Checkout (with submodules)
+        uses: actions/checkout@v4
+        with:
+          # 'recursive' is the simple, correct choice. It also pulls AMReX/pFUnit,
+          # which the Spack flavor does NOT use (Spack provides them) -- harmless
+          # but heavy. Future optimization: submodules:false + a targeted
+          #   git submodule update --init --recursive -- \
+          #     submodules/MOM6 submodules/MARBL submodules/infra/FMS2 submodules/infra/TIM
+          submodules: recursive
+
+      - name: Allow git operations on the checkout (root container)
+        run: git config --global --add safe.directory '*'
+
+      - name: Build + test turbo-stack (${{ matrix.infra }})
+        # SPACK_ROOT comes from the image (ENV). This one command runs the whole
+        # Spack-flavor pipeline: activate env -> build backend -> cmake -> ctest.
+        run: scripts/build_local_with_spack_env.sh --infra ${{ matrix.infra }} --tests

--- a/.github/workflows/turbo-cmake-container-tests.yaml
+++ b/.github/workflows/turbo-cmake-container-tests.yaml
@@ -40,7 +40,7 @@ jobs:
       CMAKE_BUILD_PARALLEL_LEVEL: "4"
     steps:
       - name: Checkout (with submodules)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           # 'recursive' is the simple, correct choice. It also pulls AMReX/pFUnit,
           # which the Spack flavor does NOT use (Spack provides them) -- harmless

--- a/.github/workflows/turbo-cmake-container-tests.yaml
+++ b/.github/workflows/turbo-cmake-container-tests.yaml
@@ -56,6 +56,19 @@ jobs:
       # rather than baked into the image (harmless on many-core machines too).
       PRTE_MCA_rmaps_default_mapping_policy: ":oversubscribe"
     steps:
+      # Fail fast, BEFORE the (heavy, recursive) checkout. build_local_with_spack_env.sh
+      # calls spack_local_environment.sh without --no-create, so its default
+      # --create-if-missing applies: a missing env would NOT error, it would start a
+      # full ~1 h from-source dependency build and die on this job's timeout with no
+      # explanation. Assert the prebaked env up front instead.
+      - name: Assert the prebaked Spack env is present
+        run: |
+          . "$SPACK_ROOT/share/spack/setup-env.sh"
+          spack env list | grep -qw turbo_stack || {
+            echo "::error::Image is missing the 'turbo_stack' Spack env -- rebuild it with build-turbo-ci-container.yaml"
+            exit 1
+          }
+
       - name: Checkout (with submodules)
         uses: actions/checkout@v7
         with:
@@ -68,6 +81,19 @@ jobs:
 
       - name: Allow git operations on the checkout (root container)
         run: git config --global --add safe.directory '*'
+
+      # The image bakes spack.yaml at image-build time and the producer is manual, so
+      # the env CI runs against can silently lag the repo's spec (see docker/README.md).
+      # Compare the copy the image kept (Dockerfile.turbo-ci COPYs it to this path)
+      # against the checkout, and surface a PR annotation when they differ.
+      # Warn, not fail: the producer/consumer decoupling is deliberate, and the CMake
+      # lane does not need every spec in spack.yaml to be present.
+      - name: Warn if the image's Spack env is stale vs the checkout
+        run: |
+          if ! diff -q /opt/turbo-spack/spack.yaml spack/spack.yaml >/dev/null; then
+            echo "::warning::Baked spack.yaml differs from the checkout -- re-run build-turbo-ci-container.yaml to refresh the image"
+            diff -u /opt/turbo-spack/spack.yaml spack/spack.yaml || true
+          fi
 
       - name: Build + test turbo-stack (${{ matrix.infra }})
         # SPACK_ROOT comes from the image (ENV). This one command runs the whole

--- a/docker/Dockerfile.turbo-ci
+++ b/docker/Dockerfile.turbo-ci
@@ -1,0 +1,89 @@
+# docker/Dockerfile.turbo-ci
+#
+# turbo-stack CI base image: Ubuntu + a system GCC/GFortran toolchain + Spack,
+# with the turbo-stack Spack environment ("turbo_stack") pre-created and
+# installed from the repo's own spack/spack.yaml
+# (cmake, ninja, gmake, openmpi, netcdf-fortran, pfunit +mpi, amrex +fortran).
+#
+# It is consumed by .github/workflows/turbo-cmake-container-tests.yaml, which runs
+#     scripts/build_local_with_spack_env.sh --infra {TIM|FMS2} --tests
+# inside this image. That script sources
+# scripts/setup_environment/spack_local_environment.sh, which finds the
+# pre-baked "turbo_stack" env and *activates it without reinstalling* (Tier 1 +
+# Tier 1.5 come from Spack), then builds only the Tier-2 backend (FMS or TIM)
+# from the submodule and runs cmake configure/build + ctest.
+#
+# The env name MUST be "turbo_stack" so it matches the default env name in
+# scripts/setup_environment/spack_local_environment.sh.
+#
+# Build context is the repo root (so spack/ is available to COPY):
+#     docker buildx build -f docker/Dockerfile.turbo-ci -t turbo-ci:gcc-openmpi .
+
+ARG BASE_IMAGE=ubuntu:24.04
+FROM ${BASE_IMAGE}
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# --- 1) OS build tools + Spack bootstrap prerequisites + system GCC/GFortran ---
+# The system compiler is registered with Spack via `spack compiler find`, so no
+# compiler is rebuilt from source. Package list mirrors the Spack prerequisites
+# already used by the repo's amrex-mini-app CI, adapted to apt.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        gfortran \
+        ca-certificates \
+        curl \
+        git \
+        gpg \
+        lsb-release \
+        python3 \
+        python3-venv \
+        file \
+        bzip2 \
+        xz-utils \
+        zstd \
+        unzip \
+        zip \
+        patch \
+        tar \
+        gzip \
+        environment-modules \
+    && rm -rf /var/lib/apt/lists/*
+
+# --- 2) Spack, pinned to a stable release for reproducibility ------------------
+ARG SPACK_REF=v1.2.2
+ENV SPACK_ROOT=/opt/spack
+RUN git clone --depth=1 --branch "${SPACK_REF}" https://github.com/spack/spack.git "${SPACK_ROOT}" \
+    && . "${SPACK_ROOT}/share/spack/setup-env.sh" \
+    && spack compiler find \
+    && spack compiler list \
+    && rm -rf "${SPACK_ROOT}/var/spack/cache"
+
+# --- 3) Bake the turbo_stack Spack environment via the repo's OWN recipe -------
+# create_spack_environment.sh does: spack env create -> concretize -> install.
+# It only needs SPACK_ROOT (set above) because we pass the spack.yaml path
+# explicitly, so no turbo-stack checkout is required at image-build time.
+COPY spack/spack.yaml                  /opt/turbo-spack/spack.yaml
+COPY spack/create_spack_environment.sh /opt/turbo-spack/create_spack_environment.sh
+# Expensive layer: concretize + install the whole dependency stack from source.
+# Kept as its own RUN so it caches independently of the best-effort cleanup below
+# (a cleanup change must not force a full dependency rebuild).
+RUN bash /opt/turbo-spack/create_spack_environment.sh turbo_stack /opt/turbo-spack/spack.yaml
+
+# Best-effort cache trimming. `spack clean -a` can abort on a symlink
+# ("Cannot call rmtree on a symbolic link"), so cleanup must never fail the build.
+RUN . "${SPACK_ROOT}/share/spack/setup-env.sh"; \
+    spack clean -a || true; \
+    rm -rf /root/.spack/cache "${SPACK_ROOT}/var/spack/cache" || true
+# NOTE: image slimming (`spack -e turbo_stack gc -y`) is intentionally deferred
+# until the pipeline is validated end-to-end, so gc can't silently remove
+# something the FMS/TIM builds need. Add it here once CI is green.
+
+# --- 4) Sanity check: the env exists and is installed --------------------------
+RUN . "${SPACK_ROOT}/share/spack/setup-env.sh" \
+    && spack env list | grep -qw turbo_stack \
+    && spack -e turbo_stack find --no-groups
+
+# SPACK_ROOT is exported (ENV above) so scripts/build_local_with_spack_env.sh
+# finds it. The env is NOT auto-activated: the repo scripts own activation.
+CMD ["/bin/bash"]

--- a/docker/Dockerfile.turbo-ci
+++ b/docker/Dockerfile.turbo-ci
@@ -84,6 +84,14 @@ RUN . "${SPACK_ROOT}/share/spack/setup-env.sh" \
     && spack env list | grep -qw turbo_stack \
     && spack -e turbo_stack find --no-groups
 
+# OpenMPI 5 (PRRTE) refuses to launch as root by default. CI job containers
+# (GitHub Actions) and local `docker run` execute as root, and the pFUnit suites
+# launch via mpirun, so opt in here. Verified sufficient for openmpi@5 (the
+# mpirun wrapper forwards --allow-run-as-root to prterun). Harmless when the
+# image is run as a non-root user -- the guard only fires for uid 0.
+ENV OMPI_ALLOW_RUN_AS_ROOT=1 \
+    OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+
 # SPACK_ROOT is exported (ENV above) so scripts/build_local_with_spack_env.sh
 # finds it. The env is NOT auto-activated: the repo scripts own activation.
 CMD ["/bin/bash"]

--- a/docker/Dockerfile.turbo-ci
+++ b/docker/Dockerfile.turbo-ci
@@ -3,7 +3,8 @@
 # turbo-stack CI base image: Ubuntu + a system GCC/GFortran toolchain + Spack,
 # with the turbo-stack Spack environment ("turbo_stack") pre-created and
 # installed from the repo's own spack/spack.yaml
-# (cmake, ninja, gmake, openmpi, netcdf-fortran, pfunit +mpi, amrex +fortran).
+# (cmake, ninja, gmake, openmpi, netcdf-fortran, parallelio, pfunit +mpi,
+# amrex +fortran).
 #
 # It is consumed by .github/workflows/turbo-cmake-container-tests.yaml, which runs
 #     scripts/build_local_with_spack_env.sh --infra {TIM|FMS2} --tests

--- a/docker/Dockerfile.turbo-ci
+++ b/docker/Dockerfile.turbo-ci
@@ -17,8 +17,10 @@
 # The env name MUST be "turbo_stack" so it matches the default env name in
 # scripts/setup_environment/spack_local_environment.sh.
 #
-# Build context is the repo root (so spack/ is available to COPY):
-#     docker buildx build -f docker/Dockerfile.turbo-ci -t turbo-ci:gcc-openmpi .
+# Build context is the repo root (so spack/ is available to COPY).  --load puts the
+# tag in the local image store: redundant on the default `docker` driver, required
+# with a `docker-container` builder, which otherwise discards the result.
+#     docker buildx build --load -f docker/Dockerfile.turbo-ci -t turbo-ci:gcc-openmpi .
 
 ARG BASE_IMAGE=ubuntu:24.04
 FROM ${BASE_IMAGE}

--- a/docker/Dockerfile.turbo-ci
+++ b/docker/Dockerfile.turbo-ci
@@ -81,9 +81,15 @@ RUN . "${SPACK_ROOT}/share/spack/setup-env.sh"; \
 # something the FMS/TIM builds need. Add it here once CI is green.
 
 # --- 4) Sanity check: the env exists and is installed --------------------------
+# `spack find` exits 0 even when specs in the env are NOT installed (it just marks
+# them "-"), so checking its exit status proves nothing. Assert the absence of any
+# "-" marker instead. The install above already fails the build via set -eo pipefail
+# in create_spack_environment.sh; this is the check that a partially-installed env
+# cannot slip through.
 RUN . "${SPACK_ROOT}/share/spack/setup-env.sh" \
     && spack env list | grep -qw turbo_stack \
-    && spack -e turbo_stack find --no-groups
+    && spack -e turbo_stack find --no-groups \
+    && ! spack -e turbo_stack find --no-groups | grep -q '^ *- '
 
 # OpenMPI 5 (PRRTE) refuses to launch as root by default. CI job containers
 # (GitHub Actions) and local `docker run` execute as root, and the pFUnit suites

--- a/docker/README.md
+++ b/docker/README.md
@@ -78,8 +78,14 @@ The build context is the repo root, so `spack/` is available to `COPY`. Only
 context stays small even in an initialized checkout.
 
 ```bash
-docker buildx build -f docker/Dockerfile.turbo-ci -t turbo-ci:gcc-openmpi .
+docker buildx build --load -f docker/Dockerfile.turbo-ci -t turbo-ci:gcc-openmpi .
 ```
+
+`--load` is what puts the tag in your local image store, so the `docker run`
+below can find it. It is redundant on the default `docker` driver but required if
+you have a `docker-container` builder active (`docker buildx create --use`) —
+without it that driver discards the result and `docker run` fails with "Unable to
+find image".
 
 Overridable build args: `BASE_IMAGE` (default `ubuntu:24.04`) and `SPACK_REF`
 (default `v1.2.2`, pinned for reproducibility).

--- a/docker/README.md
+++ b/docker/README.md
@@ -3,7 +3,7 @@
 `Dockerfile.turbo-ci` builds the CI base image for the **CMake build system**
 (the spack flavor). It bakes the repo's own Spack environment — `spack/spack.yaml`,
 env name `turbo_stack` — so CI does not recompile the dependency stack (cmake,
-ninja, gmake, OpenMPI, netcdf-fortran, pFUnit, AMReX) on every run.
+ninja, gmake, OpenMPI, netcdf-fortran, ParallelIO, pFUnit, AMReX) on every run.
 
 Rebuilding that stack from source takes ~1 hour. Reusing a prebuilt image, a
 turbo-stack build + full pFUnit suite for one backend takes ~8–9 minutes.

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,110 @@
+# `docker/` — turbo-stack CI container
+
+`Dockerfile.turbo-ci` builds the CI base image for the **CMake build system**
+(the spack flavor). It bakes the repo's own Spack environment — `spack/spack.yaml`,
+env name `turbo_stack` — so CI does not recompile the dependency stack (cmake,
+ninja, gmake, OpenMPI, netcdf-fortran, pFUnit, AMReX) on every run.
+
+Rebuilding that stack from source takes ~1 hour. Reusing a prebuilt image, a
+turbo-stack build + full pFUnit suite for one backend takes ~8–9 minutes.
+
+```
+ghcr.io/turbo-esm/turbo-stack/turbo-ci:gcc-openmpi
+```
+
+| Tag | Meaning |
+|---|---|
+| `gcc-openmpi` | **Mutable** — what CI consumes. Published only from `main` |
+| `gcc-openmpi-<short-sha>` | Immutable — always published; pin this to reproduce or bisect an image regression |
+| `buildcache` | BuildKit layer cache, not a runnable image |
+
+## The two workflows
+
+| Workflow | Role |
+|---|---|
+| `.github/workflows/build-turbo-ci-container.yaml` | **Producer** — builds the image and pushes it to GHCR. Manual only (`workflow_dispatch`), so a merge never waits on a 1-hour build. |
+| `.github/workflows/turbo-cmake-container-tests.yaml` | **Consumer** — runs `scripts/build_local_with_spack_env.sh --infra {TIM,FMS2} --tests` inside the image, on pushes to `main` and on PRs. |
+
+This is additive to the legacy `build-tests.yaml` / `unit-tests.yaml`, which
+exercise the **mkmf** `build.sh` path in the `ncarcisl/cisldev-*` containers.
+Different build system, so the two do not overlap; retiring the legacy
+workflows is a separate follow-up.
+
+## Refreshing the image after a dependency change
+
+Change `spack/spack.yaml` (or `spack/create_spack_environment.sh`, or
+`Dockerfile.turbo-ci`), then run the producer — **Actions → Build turbo-stack CI
+container → Run workflow**, or:
+
+```bash
+gh workflow run build-turbo-ci-container.yaml            # from main: refreshes gcc-openmpi
+```
+
+Nothing else picks the change up. The consumer always pulls the prebuilt
+`gcc-openmpi` tag, so **a `spack.yaml` edit has no effect on CI until the image
+is rebuilt** — that decoupling is deliberate (a merge shouldn't block on a 1-hour
+build) but it is easy to forget.
+
+To check that a recipe change even builds before you merge it, dispatch against
+your branch — the run uses that branch's `Dockerfile.turbo-ci` and `spack.yaml`:
+
+```bash
+gh workflow run build-turbo-ci-container.yaml --ref my-branch
+```
+
+A branch run publishes only `gcc-openmpi-<sha>`, never the shared `gcc-openmpi`
+tag, so it cannot hand the team an unvalidated image. To have CI actually *use*
+that image, point the consumer's `container.image` at the sha tag temporarily.
+
+## Pulling it locally
+
+The package is **private** — TURBO-ESM policy does not allow public packages —
+so an anonymous `docker pull` will fail. You need a one-time login with a
+personal access token carrying the `read:packages` scope, and read access to
+the package:
+
+```bash
+echo "$GHCR_TOKEN" | docker login ghcr.io -u <your-github-username> --password-stdin
+docker pull ghcr.io/turbo-esm/turbo-stack/turbo-ci:gcc-openmpi
+```
+
+If the pull 404s or reports `denied`, your account is probably missing package
+access — ask a TURBO-ESM owner to add you under the package's **Manage access**.
+
+## Building it locally
+
+The build context is the repo root, so `spack/` is available to `COPY`. Only
+`spack/` is used — `.dockerignore` keeps `submodules/` and `.git` out, so the
+context stays small even in an initialized checkout.
+
+```bash
+docker buildx build -f docker/Dockerfile.turbo-ci -t turbo-ci:gcc-openmpi .
+```
+
+Overridable build args: `BASE_IMAGE` (default `ubuntu:24.04`) and `SPACK_REF`
+(default `v1.2.2`, pinned for reproducibility).
+
+## Running the CI build locally
+
+The image sets `SPACK_ROOT` but deliberately does **not** activate the Spack
+environment — the repo scripts own activation. Reproducing what CI does, against
+a checkout whose submodules are already initialized:
+
+```bash
+docker run --rm -it -v "$PWD:/work" -w /work \
+    turbo-ci:gcc-openmpi \
+    bash -lc 'git config --global --add safe.directory "*" \
+              && scripts/build_local_with_spack_env.sh --infra TIM --tests'
+```
+
+Two caveats:
+
+- **Build artifacts land in your checkout owned by root**, since the container
+  runs as root against a bind mount. Pass `--build_dir` to keep them somewhere
+  disposable, or clean up afterwards.
+- **MPI oversubscription.** The pFUnit suites run `mpirun -np 4`
+  (`@test(npes=[1,2,4])`). On a machine with fewer than 4 slots, OpenMPI 5's
+  PRRTE refuses to launch with "not enough slots"; export
+  `PRTE_MCA_rmaps_default_mapping_policy=":oversubscribe"` (what the consumer
+  workflow does). Running as root is already handled — the image sets
+  `OMPI_ALLOW_RUN_AS_ROOT{,_CONFIRM}`, which OpenMPI 5 otherwise blocks.


### PR DESCRIPTION
## Description
CI coverage for the new CMake build system via a two step process, each a github action. 
1. Generate a turbo-specific container so we wait for dependency rebuilds each time. 
2. Build and run the turbo-stack unit tests in that container.

This is done via two workflows plus the image recipe:

| File | Role |
|---|---|
| `docker/Dockerfile.turbo-ci` | Ubuntu 24.04 + system gcc/gfortran + Spack `v1.2.2`, with the repo's own `spack/spack.yaml` env (`turbo_stack`) baked in via `spack/create_spack_environment.sh` |
| `.github/workflows/build-turbo-ci-container.yaml` | **Producer** — builds the image, pushes to GHCR |
| `.github/workflows/turbo-cmake-container-tests.yaml` | **Consumer** — runs `scripts/build_local_with_spack_env.sh --infra {TIM,FMS2} --tests` inside it |
| `docker/README.md` | How to pull/build/refresh the image, and the local-run gotchas |

The image bakes Tier-1/Tier-1.5 deps (cmake, ninja, gmake, OpenMPI,
netcdf-fortran, ParallelIO, pFUnit, AMReX) so a CI run only builds the Tier-2
backend from
its submodule, then configures/builds turbo-stack and runs ctest.

**Cost:** ~1 h to build the image (rare) vs **~8–9 min** per backend per CI run.

## Other things to be aware of:

- **OpenMPI 5 refuses to run as root**. The
   image sets `OMPI_ALLOW_RUN_AS_ROOT{,_CONFIRM}` since Actions job containers
   run as root.
-  **PRRTE sees only ~2 slots on a hosted runner** and won't launch the
   `npes=4` suites. The consumer sets
   `PRTE_MCA_rmaps_default_mapping_policy=":oversubscribe"`. That's a runner
   constraint, so it lives in the workflow, not the image.
- `type=gha` layer caching is unusable here — it returns `not_found` on
export and aborts the in-flight push. Uses a GHCR `:buildcache` tag instead.
- **The image is private.** Org policy disallows public packages, so pulling it
  locally needs `docker login ghcr.io` with a `read:packages` PAT
  (`docker/README.md` covers it). Anonymous pulls fail.
- **The producer is manual only** (`workflow_dispatch`). So **editing
  `spack/spack.yaml` does not reach CI until someone re-runs the producer.**
  That's deliberate to not spawn a 1 hour container build every time someone pushes to main. Validating a recipe
  change pre-merge is `gh workflow run build-turbo-ci-container.yaml --ref
  <branch>`, which publishes only a sha tag, never the shared one. To keep that
  gap visible, the consumer diffs the image's baked `spack.yaml` against the
  checkout and emits a warning annotation when they drift.
- **`:gcc-openmpi` is a mutable tag.** A producer rebuild from `main` changes
  what PRs test. `gcc-openmpi-<sha>` tags exist for pinning to a specific container build.
- **This does not replace the legacy workflows.** `build-tests.yaml` /
  `unit-tests.yaml` exercise the mkmf `./build.sh` path in the `ncarcisl`
  containers — different build system, no overlap. Retiring them is a
  follow-up, not part of this PR.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code maintenance (refactoring, optimization, etc.)
- [X] CI/CD changes

## Related Issues

Closes #248
