### PR TITLE
Run the CMake pFUnit lane against MOM6 dev/turbo-debug

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -100,6 +100,24 @@ export FMS_ROOT=$HOME/projects/FMS
 ./test_turbo_stack_locally.sh    # matrix shows each component as (override) vs (submodule)
 ```
 
+### Building a MOM6 branch instead of the pinned commit
+
+Two ways, neither needing a flag. Move the submodule onto the branch and leave
+`MOM6_ROOT` unset:
+
+```bash
+git -C submodules/MOM6 checkout dev/turbo-debug
+./test_turbo_stack_locally.sh
+git -C submodules/MOM6 checkout -
+```
+
+Or clone it elsewhere and point `MOM6_ROOT` there, which leaves the submodule
+untouched. MOM6's own submodules must be initialized either way.
+
+CI does the latter — `actions/checkout` puts the branch in a sibling directory
+and sets `MOM6_ROOT`. There is no turbo-stack-specific machinery for this: the
+build scripts only ever know about `MOM6_ROOT`.
+
 ### Spack environment
 
 Defined in `spack/spack.yaml`. Default env name: `turbo_stack`. Provides cmake, gmake, ninja, MPI (OpenMPI), NetCDF, pFUnit, AMReX. FMS and TIM are intentionally not in spack: `build_local_with_spack_env.sh` builds the selected backend via `turbo_build_fms`/`turbo_build_tim` (in `scripts/lib/common.sh`) from the local source tree (`$FMS_ROOT`/`$TIM_ROOT` or the submodule fallback). Turbo-stack tracks features ahead of the released FMS package, so linking against spack's FMS would risk quietly using a stale version.
@@ -177,7 +195,22 @@ separate lanes, in different containers:
 The legacy lane runs a matrix of compilers (oneapi, gcc14, nvhpc, clang) and MPI
 libraries (MPICH, OpenMPI) across `ubuntu-latest` and the custom
 `gha-runner-turbo` runner. The CMake lane is currently gcc + OpenMPI on
-`ubuntu-latest` only, for both infra backends (TIM, FMS2).
+`ubuntu-latest` only, over 4 cells arranged as **two groups of two**:
+`turbo-cmake-container-tests.yaml` calls the reusable `cmake-build.yaml` once per
+MOM6 source, and each call fans out over the infra backends (TIM, FMS2).
+
+| Group | MOM6 source | Character |
+|---|---|---|
+| `MOM6 pinned` | the submodule commit | deterministic gate |
+| `MOM6 dev/turbo-debug` | tip of that branch, via `MOM6_ROOT` | tracks a moving external branch |
+
+Two jobs rather than a second matrix axis because they mean different things: a
+red box then names which MOM6 source broke, and either group can be given a
+different trigger or failure policy without touching the other. The
+`dev/turbo-debug` group exists because TURBO development happens on that branch,
+so the pFUnit suite has to run against it too — possible at all only because
+MOM6's CMake build system now lives on both branches, the same CMakeLists tree
+having been ported to `dev/turbo-debug`.
 
 The `turbo-ci` image bakes the repo's `spack/spack.yaml` environment
 (`turbo_stack`) so CI does not rebuild dependencies each run. It is **private**,

--- a/.github/workflows/cmake-build.yaml
+++ b/.github/workflows/cmake-build.yaml
@@ -1,0 +1,149 @@
+# Reusable: build + ctest turbo-stack against one MOM6 source, both infra backends.
+#
+# Not triggered directly -- callers invoke it once per MOM6 source they want
+# tested (see turbo-cmake-container-tests.yaml). Each call renders as its own
+# node in the run graph, so a failure names which MOM6 source broke without
+# anyone decoding matrix cell labels.
+#
+# Runs scripts/build_local_with_spack_env.sh inside ghcr.io/.../turbo-ci (built
+# by build-turbo-ci-container.yaml). The image already has SPACK_ROOT set and the
+# "turbo_stack" Spack env installed, so the script activates that env (no
+# reinstall), builds only the selected Tier-2 backend from its submodule, then
+# cmake-configures/builds turbo-stack and runs ctest (unit tests are opt-in via
+# --tests; ctest uses --no-tests=error).
+name: turbo-stack CMake build (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      mom6_ref:
+        description: >-
+          MOM6 ref to build (branch/tag/SHA). Empty means the commit turbo-stack
+          pins as a submodule.
+        required: false
+        default: ""
+        type: string
+      mom6_label:
+        description: Human-readable name for the MOM6 source, used in job names.
+        required: false
+        default: "pinned submodule"
+        type: string
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  build-test:
+    name: build+test (${{ matrix.infra }})
+    runs-on: ubuntu-latest
+    # ~9 min when healthy. A deadlocked MPI test would otherwise hang for the 6 h
+    # default.
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        infra: [TIM, FMS2]
+    container:
+      # Must match `env.IMAGE` in build-turbo-ci-container.yaml. Hard-coded rather
+      # than derived: GHCR requires an all-lowercase path (the repo is
+      # TURBO-ESM/turbo-stack), and the `env` context is not available here.
+      # `gcc-openmpi` is a mutable tag -- a producer rebuild changes what CI
+      # tests. Pin a `gcc-openmpi-<sha>` tag to bisect an image regression.
+      image: ghcr.io/turbo-esm/turbo-stack/turbo-ci:gcc-openmpi
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    env:
+      # Hosted ubuntu-latest runners have ~4 cores; parallelize every cmake --build
+      # in the pipeline (FMS/TIM deps + turbo-stack) without per-call flags.
+      CMAKE_BUILD_PARALLEL_LEVEL: "4"
+      # The pFUnit suites launch `mpirun -np 4` (@test(npes=[1,2,4])), but PRRTE
+      # (OpenMPI 5) sees only ~2 slots (physical cores) on the hosted runner and
+      # refuses to launch 4 procs ("not enough slots"). Let it oversubscribe so
+      # the MPI tests run in CI. This is a runner constraint, so it lives here
+      # rather than baked into the image (harmless on many-core machines too).
+      PRTE_MCA_rmaps_default_mapping_policy: ":oversubscribe"
+      # For the job-summary line below. Passed through the environment rather
+      # than interpolated into the shell string directly: ${{ }} expands before
+      # the shell parses the line, so a value with shell metacharacters would be
+      # executed rather than quoted.
+      MOM6_REF: ${{ inputs.mom6_ref }}
+    steps:
+      # Fail fast, BEFORE the (heavy, recursive) checkout. build_local_with_spack_env.sh
+      # calls spack_local_environment.sh without --no-create, so its default
+      # --create-if-missing applies: a missing env would NOT error, it would start a
+      # full ~1 h from-source dependency build and die on this job's timeout with no
+      # explanation. Assert the prebaked env up front instead.
+      - name: Assert the prebaked Spack env is present
+        run: |
+          . "$SPACK_ROOT/share/spack/setup-env.sh"
+          spack env list | grep -qw turbo_stack || {
+            echo "::error::Image is missing the 'turbo_stack' Spack env -- rebuild it with build-turbo-ci-container.yaml"
+            exit 1
+          }
+
+      - name: Checkout (with submodules)
+        uses: actions/checkout@v7
+        with:
+          # 'recursive' is the simple, correct choice. It also pulls AMReX/pFUnit,
+          # which the Spack flavor does NOT use (Spack provides them) -- harmless
+          # but heavy. Future optimization: submodules:false + a targeted
+          #   git submodule update --init --recursive -- \
+          #     submodules/MOM6 submodules/MARBL submodules/infra/FMS2 submodules/infra/TIM
+          submodules: recursive
+
+      - name: Allow git operations on the checkout (root container)
+        run: git config --global --add safe.directory '*'
+
+      # The image bakes spack.yaml at image-build time and the producer is manual, so
+      # the env CI runs against can silently lag the repo's spec (see docker/README.md).
+      # Compare the copy the image kept (Dockerfile.turbo-ci COPYs it to this path)
+      # against the checkout, and surface a PR annotation when they differ.
+      # Warn, not fail: the producer/consumer decoupling is deliberate, and the CMake
+      # lane does not need every spec in spack.yaml to be present.
+      - name: Warn if the image's Spack env is stale vs the checkout
+        run: |
+          if ! diff -q /opt/turbo-spack/spack.yaml spack/spack.yaml >/dev/null; then
+            echo "::warning::Baked spack.yaml differs from the checkout -- re-run build-turbo-ci-container.yaml to refresh the image"
+            diff -u /opt/turbo-spack/spack.yaml spack/spack.yaml || true
+          fi
+
+      # Selecting the MOM6 source is orchestration, so it happens here rather than
+      # inside the build scripts, which know only MOM6_ROOT. Checked out beside
+      # the workspace rather than into submodules/MOM6, so the submodule checkout
+      # stays on the pinned commit and the two calls cannot interfere.
+      #
+      # TURBO-ESM/MOM6 is public, so the default GITHUB_TOKEN suffices -- no PAT.
+      # `ref` is a typed action input rather than a shell argument, so a value
+      # starting with '-' cannot be read as an option, and an unresolvable ref
+      # fails the step instead of silently falling back to something stale.
+      - name: Check out MOM6 ${{ inputs.mom6_label }}
+        if: inputs.mom6_ref != ''
+        uses: actions/checkout@v7
+        with:
+          repository: TURBO-ESM/MOM6
+          ref: ${{ inputs.mom6_ref }}
+          path: mom6-ref
+          # MOM6 carries its own submodules (pkg/CVMix-src, pkg/GSW-Fortran) and
+          # its top-level CMakeLists hard-fails without them.
+          submodules: recursive
+          # Nothing here needs history; this is a build input, not a repo we work in.
+          fetch-depth: 1
+
+      # The resolved SHA goes to the job summary because a branch tip is
+      # ephemeral: "which MOM6 did this test?" has to be answerable from the run
+      # page, not only from log text that ages out with the run.
+      - name: Point MOM6_ROOT at it
+        if: inputs.mom6_ref != ''
+        run: |
+          echo "MOM6_ROOT=$GITHUB_WORKSPACE/mom6-ref" >> "$GITHUB_ENV"
+          echo "MOM6 \`$MOM6_REF\` @ \`$(git -C "$GITHUB_WORKSPACE/mom6-ref" rev-parse HEAD)\`" \
+            >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Build + test turbo-stack (${{ matrix.infra }}, MOM6 ${{ inputs.mom6_label }})
+        # SPACK_ROOT comes from the image (ENV). This one command runs the whole
+        # Spack-flavor pipeline: activate env -> build backend -> cmake -> ctest.
+        # Identical for every call: MOM6_ROOT (set above, or unset for the pinned
+        # call) is what selects the MOM6 source.
+        run: scripts/build_local_with_spack_env.sh --infra ${{ matrix.infra }} --tests

--- a/.github/workflows/turbo-cmake-container-tests.yaml
+++ b/.github/workflows/turbo-cmake-container-tests.yaml
@@ -1,11 +1,38 @@
-# Consumer: exercise the NEW CMake build system inside the turbo-stack CI image.
+# Consumer: exercise the NEW CMake build system against each MOM6 source we care
+# about. All the build logic lives once in cmake-build.yaml; this file only says
+# *which* MOM6 sources get tested.
 #
-# Runs scripts/build_local_with_spack_env.sh for both infra backends (TIM, FMS2)
-# inside ghcr.io/.../turbo-ci (built by build-turbo-ci-container.yaml). The image
-# already has SPACK_ROOT set and the "turbo_stack" Spack env installed, so the
-# script activates that env (no reinstall), builds only the selected Tier-2
-# backend from its submodule, then cmake-configures/builds turbo-stack and runs
-# ctest (unit tests are opt-in via --tests; ctest uses --no-tests=error).
+# Two calls, deliberately separate jobs rather than a second matrix axis:
+#
+#     MOM6 pinned submodule ─┬── build+test (TIM)
+#                            └── build+test (FMS2)
+#
+#     MOM6 dev/turbo-debug ──┬── build+test (TIM)
+#                            └── build+test (FMS2)
+#
+# They mean different things -- one is a deterministic gate on the commit
+# turbo-stack pins, the other tracks the tip of a branch in another repository
+# that moves independently of this one. Rendering them as one 4-cell matrix
+# implies they are the same kind of check. As separate nodes in the run graph, a
+# red box names which MOM6 source broke, and either group can later be given a
+# different trigger or failure policy without touching the other.
+#
+# No edge between them: they share nothing and neither gates the other.
+#
+# Reproducible locally without pushing a branch. The pinned group is just the
+# default; for the other, either move the submodule onto the branch, or point
+# MOM6_ROOT at a separate clone:
+#
+#     ./test_turbo_stack_locally.sh                        # the pinned group
+#
+#     git -C submodules/MOM6 checkout dev/turbo-debug      # simplest
+#     ./test_turbo_stack_locally.sh
+#     git -C submodules/MOM6 checkout -                    # put it back
+#
+#     git clone --depth 1 -b dev/turbo-debug \
+#         https://github.com/TURBO-ESM/MOM6 /tmp/mom6-debug
+#     git -C /tmp/mom6-debug submodule update --init --recursive --depth 1
+#     MOM6_ROOT=/tmp/mom6-debug ./test_turbo_stack_locally.sh
 name: turbo-stack CMake build (container)
 
 # Only main + PRs. The sibling workflows (build-tests.yaml, unit-tests.yaml) also
@@ -25,77 +52,28 @@ permissions:
   packages: read
 
 jobs:
-  build-test:
-    name: build+test (${{ matrix.infra }})
-    runs-on: ubuntu-latest
-    # ~9 min when healthy. A deadlocked MPI test would otherwise hang for the 6 h
-    # default.
-    timeout-minutes: 60
-    strategy:
-      fail-fast: false
-      matrix:
-        infra: [TIM, FMS2]
-    container:
-      # Must match `env.IMAGE` in build-turbo-ci-container.yaml. Hard-coded rather
-      # than derived: GHCR requires an all-lowercase path (the repo is
-      # TURBO-ESM/turbo-stack), and the `env` context is not available here.
-      # `gcc-openmpi` is a mutable tag -- a producer rebuild changes what CI
-      # tests. Pin a `gcc-openmpi-<sha>` tag to bisect an image regression.
-      image: ghcr.io/turbo-esm/turbo-stack/turbo-ci:gcc-openmpi
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    env:
-      # Hosted ubuntu-latest runners have ~4 cores; parallelize every cmake --build
-      # in the pipeline (FMS/TIM deps + turbo-stack) without per-call flags.
-      CMAKE_BUILD_PARALLEL_LEVEL: "4"
-      # The pFUnit suites launch `mpirun -np 4` (@test(npes=[1,2,4])), but PRRTE
-      # (OpenMPI 5) sees only ~2 slots (physical cores) on the hosted runner and
-      # refuses to launch 4 procs ("not enough slots"). Let it oversubscribe so
-      # the MPI tests run in CI. This is a runner constraint, so it lives here
-      # rather than baked into the image (harmless on many-core machines too).
-      PRTE_MCA_rmaps_default_mapping_policy: ":oversubscribe"
-    steps:
-      # Fail fast, BEFORE the (heavy, recursive) checkout. build_local_with_spack_env.sh
-      # calls spack_local_environment.sh without --no-create, so its default
-      # --create-if-missing applies: a missing env would NOT error, it would start a
-      # full ~1 h from-source dependency build and die on this job's timeout with no
-      # explanation. Assert the prebaked env up front instead.
-      - name: Assert the prebaked Spack env is present
-        run: |
-          . "$SPACK_ROOT/share/spack/setup-env.sh"
-          spack env list | grep -qw turbo_stack || {
-            echo "::error::Image is missing the 'turbo_stack' Spack env -- rebuild it with build-turbo-ci-container.yaml"
-            exit 1
-          }
+  # The commit turbo-stack pins as a submodule. Deterministic: it only changes
+  # when someone moves the pointer in a reviewable commit.
+  pinned:
+    name: MOM6 pinned submodule
+    uses: ./.github/workflows/cmake-build.yaml
+    with:
+      mom6_ref: ""
+      mom6_label: pinned submodule
 
-      - name: Checkout (with submodules)
-        uses: actions/checkout@v7
-        with:
-          # 'recursive' is the simple, correct choice. It also pulls AMReX/pFUnit,
-          # which the Spack flavor does NOT use (Spack provides them) -- harmless
-          # but heavy. Future optimization: submodules:false + a targeted
-          #   git submodule update --init --recursive -- \
-          #     submodules/MOM6 submodules/MARBL submodules/infra/FMS2 submodules/infra/TIM
-          submodules: recursive
-
-      - name: Allow git operations on the checkout (root container)
-        run: git config --global --add safe.directory '*'
-
-      # The image bakes spack.yaml at image-build time and the producer is manual, so
-      # the env CI runs against can silently lag the repo's spec (see docker/README.md).
-      # Compare the copy the image kept (Dockerfile.turbo-ci COPYs it to this path)
-      # against the checkout, and surface a PR annotation when they differ.
-      # Warn, not fail: the producer/consumer decoupling is deliberate, and the CMake
-      # lane does not need every spec in spack.yaml to be present.
-      - name: Warn if the image's Spack env is stale vs the checkout
-        run: |
-          if ! diff -q /opt/turbo-spack/spack.yaml spack/spack.yaml >/dev/null; then
-            echo "::warning::Baked spack.yaml differs from the checkout -- re-run build-turbo-ci-container.yaml to refresh the image"
-            diff -u /opt/turbo-spack/spack.yaml spack/spack.yaml || true
-          fi
-
-      - name: Build + test turbo-stack (${{ matrix.infra }})
-        # SPACK_ROOT comes from the image (ENV). This one command runs the whole
-        # Spack-flavor pipeline: activate env -> build backend -> cmake -> ctest.
-        run: scripts/build_local_with_spack_env.sh --infra ${{ matrix.infra }} --tests
+  # The tip of MOM6's dev/turbo-debug, which is what issue #251 asked for: TURBO
+  # development happens on that branch, so the pFUnit suite has to run against it
+  # and not only against the pin.
+  #
+  # Blocking, deliberately. This couples turbo-stack's PR status to a branch in
+  # another repository -- a push to MOM6 can redden a turbo-stack PR that had
+  # nothing to do with it. Accepted for now: the two are co-developed by the same
+  # team and catching integration breakage immediately is worth more than an
+  # always-green gate. If that stops being true, `continue-on-error: true` here
+  # downgrades it to a warning without touching anything else.
+  turbo-debug:
+    name: MOM6 dev/turbo-debug
+    uses: ./.github/workflows/cmake-build.yaml
+    with:
+      mom6_ref: dev/turbo-debug
+      mom6_label: dev/turbo-debug

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -194,6 +194,39 @@ precedence below; MOM6's CMakeLists reads `$MOM6_ROOT` directly. The testing
 matrix printed at the top of each driver shows whether each component resolved to
 its submodule or to an override.
 
+### Building a MOM6 branch you don't have checked out
+
+`MOM6_ROOT` needs a tree you already have. To build MOM6's `dev/turbo-debug`
+development branch instead of the pinned commit, there are two ways and neither
+needs a flag:
+
+**Move the submodule onto the branch.** Simplest, and `MOM6_ROOT` stays unset:
+
+```bash
+git -C submodules/MOM6 checkout dev/turbo-debug
+./test_turbo_stack_locally.sh
+git -C submodules/MOM6 checkout -          # put it back when done
+```
+
+**Or point `MOM6_ROOT` at a separate clone.** Leaves the submodule alone, so an
+interrupted run cannot strand it on another ref:
+
+```bash
+git clone --depth 1 -b dev/turbo-debug \
+    https://github.com/TURBO-ESM/MOM6 /tmp/mom6-debug
+git -C /tmp/mom6-debug submodule update --init --recursive --depth 1
+MOM6_ROOT=/tmp/mom6-debug ./test_turbo_stack_locally.sh
+```
+
+MOM6's own submodules (`pkg/CVMix-src`, `pkg/GSW-Fortran`) must be initialized
+either way -- its top-level `CMakeLists.txt` hard-fails without them.
+
+CI does the second of these: the `MOM6 dev/turbo-debug` group checks the branch
+out with `actions/checkout` into a sibling directory and points `MOM6_ROOT`
+there, so the build scripts see nothing unusual. The testing matrix then reports
+MOM6 as an override at the real SHA, so a log says exactly which commit was
+tested.
+
 ---
 
 ## Where do dep builds + installs land?
@@ -207,6 +240,9 @@ The orchestrators derive the deps location from `--build_dir`:
 
 - The end-to-end test drivers build each backend independently under
   `$TURBO_BUILD_SYSTEM_TEST_DIR/turbo-stack-with-<backend>/` (deps in its `deps/` subdir).
+
+An out-of-tree MOM6 source (`MOM6_ROOT`) is a build *input*, not a build
+artifact, so it does not land here at all — see above.
 
 In the explicit flow you pass the `build` and `install` roots straight to the
 `turbo_build_*` wrappers, so any layout is possible.

--- a/tests/interface/MOM_coms_infra/test_broadcast_IntArray.pf
+++ b/tests/interface/MOM_coms_infra/test_broadcast_IntArray.pf
@@ -26,10 +26,15 @@ contains
  
     rank = this%getProcessRank()
    
-    !------------------------------- 
+    !-------------------------------
     ! allocate and initialize memory
     !-------------------------------
-    call actual_c%alloc(actual,lb=[0,0,-1],ub=[len1,len2,len3])
+    ! Allocate, then view, as two steps -- see the note in
+    ! test_broadcast_RealArray.pf: the one-step `alloc(actual,lb=,ub=)` does
+    ! not exist on dev/turbo-debug, where the pointer-associating overloads
+    ! moved into a separate `allocView` generic.
+    call actual_c%allocInt(lb=[0,0,-1],ub=[len1,len2,len3])
+    call actual_c%view(actual)
     allocate(expected(0:len1,0:len2,-1:len3))
    
     actual = rank

--- a/tests/interface/MOM_coms_infra/test_broadcast_RealArray.pf
+++ b/tests/interface/MOM_coms_infra/test_broadcast_RealArray.pf
@@ -26,10 +26,17 @@ contains
  
     rank = dble(this%getProcessRank())
    
-    !------------------------------- 
+    !-------------------------------
     ! allocate and initialize memory
     !-------------------------------
-    call actual_c%alloc(actual,lb=[0,0,-1],ub=[len1,len2,len3])
+    ! Allocate, then view, as two steps.  The one-step spelling
+    ! `alloc(actual,lb=,ub=)` is not portable across the MOM6 branches this
+    ! suite is built against: on dev/turbo-debug the pointer-associating
+    ! overloads moved out of the `alloc` generic into a new `allocView` one,
+    ! which dev/turbo does not have.  `allocReal` and the `view` generic are
+    ! spelled the same on both branches and for both infra backends.
+    call actual_c%allocReal(lb=[0,0,-1],ub=[len1,len2,len3])
+    call actual_c%view(actual)
     allocate(expected(0:len1,0:len2,-1:len3))
    
     actual = rank


### PR DESCRIPTION
Closes nothing on its own — see the note at the bottom.

TURBO development happens on MOM6's `dev/turbo-debug`, so the pFUnit suite has
to run against that branch, not only against the commit turbo-stack pins.

## What this does

Adds a second MOM6 source to the CMake lane, taking it from 2 cells to 4,
arranged as two independent jobs:

```
MOM6 pinned submodule ─┬── build+test (TIM)      deterministic gate
                       └── build+test (FMS2)

MOM6 dev/turbo-debug ──┬── build+test (TIM)      tracks a moving branch
                       └── build+test (FMS2)
```

The build itself moves to a reusable workflow (`cmake-build.yaml`,
`on: workflow_call`) called once per MOM6 source, so the five steps exist once
rather than twice.

**No new turbo-stack code selects the MOM6 source.** `MOM6_ROOT` already chose
which MOM6 tree gets built and predates this branch; the only open question was
how to get the branch onto disk, and `actions/checkout` does that —
`TURBO-ESM/MOM6` is public, so the default `GITHUB_TOKEN` suffices. It lands in a
sibling directory with `MOM6_ROOT` pointed at it.

So **no builder, driver, or `common.sh` change appears in this diff.** The build
scripts know only `MOM6_ROOT` and nothing about refs.

## Why the broadcast tests had to change

Adding a second MOM6 source imposes a constraint that did not exist before:
**turbo-stack's own test sources now have to compile against two MOM6 branches
at once.** Previously they only ever saw the pinned commit, so they could use
whatever API that commit offered. Now the same file is compiled against both, and
anything the two branches spell differently breaks one of them.

`test_broadcast_{Int,Real}Array` hit exactly that. They allocated and associated a
pointer in one call:

```fortran
call actual_c%alloc(actual, lb=[0,0,-1], ub=[len1,len2,len3])
```

MOM6 #31 moved the pointer-associating overloads out of the `alloc` generic into
a new `allocView` on `dev/turbo-debug`. There is no one-step spelling that works
on both — `dev/turbo` has no `allocView`, and `dev/turbo-debug` no longer has a
pointer-taking `alloc`. So it becomes the two steps that *are* spelled
identically on both branches and for both infra backends:

```fortran
call actual_c%allocReal(lb=[0,0,-1], ub=[len1,len2,len3])   ! allocInt for IntArray_t
call actual_c%view(actual)
```

`allocReal`/`allocInt` are named directly rather than through `alloc`, because
`dev/turbo`'s `alloc` generic covers only the rank-specific `allocReal1D..4D`,
not `allocReal` itself.

Worth noting this is the first instance of the class of problem the new lane
exists to catch — an upstream API change that compiles fine against the pin and
breaks against the development branch. It was found by building, not by review.
It also means this constraint is now standing: test sources have to stay within
what both branches spell the same way, or the `dev/turbo-debug` cells go red.

## Why two jobs instead of a second matrix axis

They mean different things. `MOM6 pinned submodule` only changes when someone
moves the submodule pointer in a reviewable commit. `MOM6 dev/turbo-debug` tracks
the tip of a branch in another repository that moves independently of this one —
a push to MOM6 can redden a turbo-stack PR that had nothing to do with it.

A single matrix implies those are the same kind of check, and a failure reads as
"one of four cells" rather than naming which MOM6 source broke.

**The `dev/turbo-debug` group blocks, deliberately.** The two repos are
co-developed by the same team, and catching integration breakage immediately is
worth more than an always-green gate. If that stops being true,
`continue-on-error: true` on that one job downgrades it to a warning without
touching anything else — which is the practical payoff of the split, and was not
expressible as a matrix cell.

## Running it locally

Neither group needs a flag. The pinned group is just the default; for the other,
either move the submodule onto the branch or point `MOM6_ROOT` at a clone:

```bash
git -C submodules/MOM6 checkout dev/turbo-debug
./test_turbo_stack_locally.sh
git -C submodules/MOM6 checkout -
```

## Verification

Every cell, in CI and locally (spack flavor, gcc/OpenMPI):

| | MOM6 pinned submodule | MOM6 `dev/turbo-debug` |
|---|---|---|
| **TIM** | 40/40 | 40/40 |
| **FMS2** | 40/40 | 40/40 |

Checked that the two groups genuinely build different sources rather than both
silently falling back to the pin — the `dev/turbo-debug` cells reference the
checked-out tree throughout their build logs, the pinned cells never do.

The resolved SHA is written to the job summary: a branch tip is ephemeral, so
"which MOM6 did this test?" has to be answerable from the run page and not only
from log text that ages out with the run.

## Not addressed here

`dev/turbo-debug` guards its AMReX bridge call sites with `#ifdef _TIM`, which
MOM6's CMake never defines — 6 guards, all in `MOM_continuity_PPM.F90`. So the
`TIM × dev/turbo-debug` cell is green while those kernels are compiled out.
Tracked in #258.

## Note on #251

This does not carry a closing keyword. #251 has two sub-issues — #257 (done) and
#258 (open) — and closing the parent while the bridge gap is outstanding would
lose it. Close #251 by hand when #258 lands, or leave it open as the umbrella.

*(GitHub may still show #251 as linked: a `connected` event from 2026-08-12
persists independently of the body and commits, and can only be removed from
#251's Development panel.)*

## Prerequisite

TURBO-ESM/MOM6#35 — merged. `dev/turbo-debug` had no CMakeLists before it, and
this lane delegates entirely to MOM6's own CMake, so the two `dev/turbo-debug`
cells could not configure at all until it landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
