### PR TITLE
Fix: pin the Spack target so the CI image is portable across runners

### DIFF
--- a/docker/Dockerfile.turbo-ci
+++ b/docker/Dockerfile.turbo-ci
@@ -68,10 +68,24 @@ RUN git clone --depth=1 --branch "${SPACK_REF}" https://github.com/spack/spack.g
 # explicitly, so no turbo-stack checkout is required at image-build time.
 COPY spack/spack.yaml                  /opt/turbo-spack/spack.yaml
 COPY spack/create_spack_environment.sh /opt/turbo-spack/create_spack_environment.sh
+# Build for a portable baseline rather than for the machine doing the build.
+# Spack's default target is the microarchitecture it detects while concretizing,
+# which is correct locally and wrong here: this image is produced on one hosted
+# runner and consumed on a *different* one, from a fleet mixing CPU generations.
+# Unpinned, the 2026-08-06 image concretized to x86_64_v4 (AVX-512) because that
+# producer drew a runner with AVX-512, and consumer jobs on runners without it
+# died in Spack's own cmake with "Illegal instruction (core dumped)".
+#
+# x86_64_v3 is the AVX2 baseline (Haswell 2013+, Zen 2017+) that every hosted
+# runner satisfies. It lives here, not in spack.yaml, because that spec is shared
+# with local builds -- an x86 level hard-coded there fails concretization on an
+# Apple Silicon laptop. See docker/README.md.
+ARG SPACK_TARGET=x86_64_v3
 # Expensive layer: concretize + install the whole dependency stack from source.
 # Kept as its own RUN so it caches independently of the best-effort cleanup below
 # (a cleanup change must not force a full dependency rebuild).
-RUN bash /opt/turbo-spack/create_spack_environment.sh turbo_stack /opt/turbo-spack/spack.yaml
+RUN TURBO_SPACK_TARGET="${SPACK_TARGET}" \
+    bash /opt/turbo-spack/create_spack_environment.sh turbo_stack /opt/turbo-spack/spack.yaml
 
 # Best-effort cache trimming. `spack clean -a` can abort on a symlink
 # ("Cannot call rmtree on a symbolic link"), so cleanup must never fail the build.

--- a/docker/README.md
+++ b/docker/README.md
@@ -56,14 +56,24 @@ A branch run publishes only `gcc-openmpi-<sha>`, never the shared `gcc-openmpi`
 tag, so it cannot hand the team an unvalidated image. To have CI actually *use*
 that image, point the consumer's `container.image` at the sha tag temporarily.
 
-### Why `spack.yaml` pins `target=x86_64_v3`
+### Why the image pins a Spack target
 
-Do not remove it. Spack's default is to concretize for the microarchitecture of
-whatever machine runs `spack concretize`, and to compile everything with flags
-for it. That is right on a workstation and wrong for a container image, which is
-built on one machine and run on another — here, produced on a hosted GitHub
-runner and consumed on a *different* hosted runner, from a fleet that mixes CPU
+`Dockerfile.turbo-ci` sets `TURBO_SPACK_TARGET=x86_64_v3` (via `ARG
+SPACK_TARGET`) when it runs `create_spack_environment.sh`. Do not remove it.
+
+Spack's default is to concretize for the microarchitecture of whatever machine
+runs `spack concretize`, and to compile everything with flags for it. That is
+right on a workstation and wrong for a container image, which is built on one
+machine and run on another — here, produced on a hosted GitHub runner and
+consumed on a *different* hosted runner, from a fleet that mixes CPU
 generations.
+
+**The pin lives in the Dockerfile, not in `spack/spack.yaml`.** That spec is
+shared with local builds (`scripts/setup_environment/spack_local_environment.sh`
+→ the same `create_spack_environment.sh`), and an x86 level hard-coded there
+fails concretization outright on an Apple Silicon laptop — `require:` is a hard
+constraint, not a preference. Unset, `TURBO_SPACK_TARGET` leaves Spack's
+per-host default alone, which is what a local build wants.
 
 Without the pin, the target is decided by luck of the draw at image-build time.
 The 2026-08-06 image drew a runner with AVX-512 and concretized everything to
@@ -80,7 +90,13 @@ SIGILL'd in another. It is not flaky; it is a portability bug that reappears on
 every producer rebuild until the target is stated.
 
 `x86_64_v3` is the AVX2 baseline (Intel Haswell 2013+, AMD Zen 2017+), which
-every hosted runner satisfies. To check what an image actually got:
+every hosted runner satisfies. To build the image for a different baseline:
+
+```bash
+docker build --build-arg SPACK_TARGET=x86_64_v2 -f docker/Dockerfile.turbo-ci .
+```
+
+To check what an image actually got:
 
 ```bash
 docker run --rm --entrypoint bash <image> -lc \

--- a/docker/README.md
+++ b/docker/README.md
@@ -56,6 +56,39 @@ A branch run publishes only `gcc-openmpi-<sha>`, never the shared `gcc-openmpi`
 tag, so it cannot hand the team an unvalidated image. To have CI actually *use*
 that image, point the consumer's `container.image` at the sha tag temporarily.
 
+### Why `spack.yaml` pins `target=x86_64_v3`
+
+Do not remove it. Spack's default is to concretize for the microarchitecture of
+whatever machine runs `spack concretize`, and to compile everything with flags
+for it. That is right on a workstation and wrong for a container image, which is
+built on one machine and run on another — here, produced on a hosted GitHub
+runner and consumed on a *different* hosted runner, from a fleet that mixes CPU
+generations.
+
+Without the pin, the target is decided by luck of the draw at image-build time.
+The 2026-08-06 image drew a runner with AVX-512 and concretized everything to
+`target=x86_64_v4`, `cmake` included. Consumer jobs that then landed on a runner
+without AVX-512 died inside Spack's own `cmake`:
+
+```
+build_dep.sh: line 91: Illegal instruction (core dumped) cmake -S ... -B ...
+```
+
+It reads as a flaky build, because it is decided per job by which CPU the runner
+drew — in one run the same `cmake` command configured fine in one job and
+SIGILL'd in another. It is not flaky; it is a portability bug that reappears on
+every producer rebuild until the target is stated.
+
+`x86_64_v3` is the AVX2 baseline (Intel Haswell 2013+, AMD Zen 2017+), which
+every hosted runner satisfies. To check what an image actually got:
+
+```bash
+docker run --rm --entrypoint bash <image> -lc \
+  '. $SPACK_ROOT/share/spack/setup-env.sh; spack -e turbo_stack find --format "{name} {arch}"'
+```
+
+Producer logs show the same thing without a pull — grep a run for `target=`.
+
 ## Pulling it locally
 
 The package is **private** — TURBO-ESM policy does not allow public packages —

--- a/spack/create_spack_environment.sh
+++ b/spack/create_spack_environment.sh
@@ -14,6 +14,14 @@
 # Optional environment variables:
 #   TURBO_STACK_ROOT  Path to the turbo-stack repository root. Required when
 #                     using the default spack-yaml argument.
+#   TURBO_SPACK_TARGET  Microarchitecture to build for, e.g. x86_64_v3. When
+#                     unset (the normal case for a local build) Spack uses its
+#                     own default: the microarchitecture of THIS machine. Set it
+#                     only when the environment will run somewhere other than
+#                     where it is built -- that is, for a container image. It is
+#                     applied as a requirement, so an impossible value (an x86
+#                     level on Apple Silicon) fails concretization rather than
+#                     silently degrading.
 #
 # Creates a named Spack environment, installs all packages, and prints
 # the activation command. Does NOT activate — user must run the printed command.
@@ -72,6 +80,15 @@ fi
 echo "Creating Spack environment '$spack_environment_name' from $spack_environment_yaml_file ..."
 spack env create "$spack_environment_name" "$spack_environment_yaml_file"
 spack env activate "$spack_environment_name"
+
+# Portability pin for environments that run somewhere other than where they were
+# built (i.e. a container image). Applied here rather than in spack.yaml because
+# that spec is shared with local builds, where a hard-coded x86 level would break
+# concretization on an Apple Silicon machine.
+if [[ -n "${TURBO_SPACK_TARGET:-}" ]]; then
+    echo "Pinning target to $TURBO_SPACK_TARGET (TURBO_SPACK_TARGET) ..."
+    spack config add "packages:all:require:target=${TURBO_SPACK_TARGET}"
+fi
 
 echo "Concretizing ..."
 spack concretize

--- a/spack/spack.yaml
+++ b/spack/spack.yaml
@@ -11,17 +11,18 @@ spack:
   view: true
   concretizer:
     unify: true
+  # Deliberately NOT constraining `packages: all: target:` here. This file is
+  # shared by everyone who builds the Spack flavor locally
+  # (scripts/setup_environment/spack_local_environment.sh -> this spec), so a
+  # hard-coded x86 target would make concretization fail outright on an Apple
+  # Silicon laptop. Spack's per-host default is the right behaviour for a local
+  # build -- it is only wrong for a *container image*, which is built on one
+  # machine and run on another.
+  #
+  # The turbo-ci image therefore pins its own target at image-build time, via
+  # TURBO_SPACK_TARGET in create_spack_environment.sh (set by
+  # docker/Dockerfile.turbo-ci). See "Why the image pins a Spack target" in
+  # docker/README.md.
   packages:
-    all:
-      # Build for a portable baseline instead of the concretizing machine's CPU.
-      #
-      # Spack's default is target=<microarchitecture detected on the build host>,
-      # and it compiles everything with flags for it.  That is right for a
-      # compiling and running on the same machine but could be wrong for a container image,
-      # which gets built on one machine and run on another: the turbo-ci image is produced on a hosted
-      # GitHub runner and consumed on a *different* hosted runner, and that fleet
-      # is a mix of CPU generations. Pin it to x86_64_v3 to avoid this (assuming all runners can handle this).
-      require:
-        - target=x86_64_v3
     mpi:
       require: openmpi

--- a/spack/spack.yaml
+++ b/spack/spack.yaml
@@ -17,21 +17,10 @@ spack:
       #
       # Spack's default is target=<microarchitecture detected on the build host>,
       # and it compiles everything with flags for it.  That is right for a
-      # workstation and wrong for a container image, which gets built on one
-      # machine and run on another: the turbo-ci image is produced on a hosted
+      # compiling and running on the same machine but could be wrong for a container image,
+      # which gets built on one machine and run on another: the turbo-ci image is produced on a hosted
       # GitHub runner and consumed on a *different* hosted runner, and that fleet
-      # is a mix of CPU generations.
-      #
-      # Left unset, the 2026-08-06 image concretized to target=x86_64_v4 -- the
-      # AVX-512 baseline -- because that producer happened to draw a runner with
-      # AVX-512.  Consumer jobs landing on a runner without it (AMD EPYC Zen 1-3,
-      # or Intel parts with AVX-512 fused off) then died in spack's own cmake:
-      #
-      #     build_dep.sh: line 91: Illegal instruction (core dumped) cmake -S ...
-      #
-      # x86_64_v3 is the AVX2 baseline (Haswell 2013+, Zen 2017+), which every
-      # hosted runner satisfies.  It is also the level the last known-good image
-      # effectively had (it concretized to `skylake`, an AVX2 target).
+      # is a mix of CPU generations. Pin it to x86_64_v3 to avoid this (assuming all runners can handle this).
       require:
         - target=x86_64_v3
     mpi:

--- a/spack/spack.yaml
+++ b/spack/spack.yaml
@@ -11,18 +11,6 @@ spack:
   view: true
   concretizer:
     unify: true
-  # Deliberately NOT constraining `packages: all: target:` here. This file is
-  # shared by everyone who builds the Spack flavor locally
-  # (scripts/setup_environment/spack_local_environment.sh -> this spec), so a
-  # hard-coded x86 target would make concretization fail outright on an Apple
-  # Silicon laptop. Spack's per-host default is the right behaviour for a local
-  # build -- it is only wrong for a *container image*, which is built on one
-  # machine and run on another.
-  #
-  # The turbo-ci image therefore pins its own target at image-build time, via
-  # TURBO_SPACK_TARGET in create_spack_environment.sh (set by
-  # docker/Dockerfile.turbo-ci). See "Why the image pins a Spack target" in
-  # docker/README.md.
   packages:
     mpi:
       require: openmpi

--- a/spack/spack.yaml
+++ b/spack/spack.yaml
@@ -12,5 +12,27 @@ spack:
   concretizer:
     unify: true
   packages:
+    all:
+      # Build for a portable baseline instead of the concretizing machine's CPU.
+      #
+      # Spack's default is target=<microarchitecture detected on the build host>,
+      # and it compiles everything with flags for it.  That is right for a
+      # workstation and wrong for a container image, which gets built on one
+      # machine and run on another: the turbo-ci image is produced on a hosted
+      # GitHub runner and consumed on a *different* hosted runner, and that fleet
+      # is a mix of CPU generations.
+      #
+      # Left unset, the 2026-08-06 image concretized to target=x86_64_v4 -- the
+      # AVX-512 baseline -- because that producer happened to draw a runner with
+      # AVX-512.  Consumer jobs landing on a runner without it (AMD EPYC Zen 1-3,
+      # or Intel parts with AVX-512 fused off) then died in spack's own cmake:
+      #
+      #     build_dep.sh: line 91: Illegal instruction (core dumped) cmake -S ...
+      #
+      # x86_64_v3 is the AVX2 baseline (Haswell 2013+, Zen 2017+), which every
+      # hosted runner satisfies.  It is also the level the last known-good image
+      # effectively had (it concretized to `skylake`, an AVX2 target).
+      require:
+        - target=x86_64_v3
     mpi:
       require: openmpi


### PR DESCRIPTION
**The CMake CI lane is broken on `main` right now.** Both cells die before
compiling anything of ours:

```
build_dep.sh: line 91: Illegal instruction (core dumped) cmake -S ... -B ...
```

Spack's own `cmake` takes SIGILL. Three files; no behaviour change to any
existing caller.

## Cause

`spack/spack.yaml` constrains no target, so `spack concretize` resolves `target`
to the microarchitecture of whatever machine concretizes, and compiles the whole
stack for it. Correct on a workstation; wrong for a container image, which is
built on one machine and run on another — this one is produced on a hosted GitHub
runner and consumed on a *different* hosted runner, from a fleet that mixes CPU
generations.

So the image's ISA baseline has been decided by luck of the draw at build time:

| image | concretized target | ISA | lane |
|---|---|---|---|
| 2026-07-21 | `skylake` ×68 | AVX2 | green |
| **2026-08-06** (what CI pulls) | **`x86_64_v4` ×69** | **AVX-512** | SIGILL |

That producer drew a runner *with* AVX-512, so everything — `cmake@3.31.11`
included — was built as `target=x86_64_v4`. Consumer jobs landing on a runner
without AVX-512 can't decode those instructions.

## Why it looks flaky but isn't

It's decided per job by which CPU the runner draws. In run
[31553996847](https://github.com/TURBO-ESM/turbo-stack/actions/runs/31553996847)
the *same* `cmake -S submodules/infra/TIM` command, from the *same* image,
configured fine in one job and SIGILL'd in another. It will recur on every
producer rebuild until the target is stated.

It also explains the timeline: green on Aug 5 against the `skylake` image, broken
after the Aug 6 rebuild tightened the target.

## Fix

Build the image for `x86_64_v3` — the AVX2 baseline (Intel Haswell 2013+, AMD
Zen 2017+), satisfied by every hosted runner, and the level the last known-good
image effectively had.

**The pin is scoped to the image, not to the shared spec.** Putting
`packages: all: require: target=x86_64_v3` in `spack/spack.yaml` — the first
attempt here — would have broken teammates on Apple Silicon: that file is also
what local builds use (`spack_local_environment.sh` → `create_spack_environment.sh`
→ the same file), and `require:` is a hard constraint, not a preference.
Confirmed by requiring the mirror image (`target=aarch64` on an x86 host):
concretization exits 1, it does not degrade gracefully.

So the pin lives where the portability problem actually is:

- `spack/create_spack_environment.sh` honours a new optional `TURBO_SPACK_TARGET`,
  applying it with `spack config add` after `spack env create`. Unset — the normal
  case — Spack's per-host default applies, unchanged. Every existing caller is
  therefore unaffected.
- `docker/Dockerfile.turbo-ci` sets it via `ARG SPACK_TARGET=x86_64_v3`.
- `docker/README.md` gets a short section on why the pin exists, why it is *not*
  in `spack.yaml`, and how to check what an image actually got — so it doesn't get
  dropped as boilerplate later.

All three paths verified by concretizing inside the CI image, against the same
Spack the Dockerfile pins (`SPACK_REF=v1.2.2`):

```
unset (local build)          rc=0   host native
TURBO_SPACK_TARGET=x86_64_v3 rc=0   71 specs, all x86_64_v3
impossible (aarch64 on x86)  rc=1   fails loudly
```

No conflicts — notably none with the external gcc/glibc, which was the real risk
and why this was checked rather than assumed.

## Validated end-to-end on real runners

Built the image from this branch and ran the CMake lane against it
(full evidence in the comment below) — both cells that SIGILL on the
current `main` image reach **ctest 40/40**:

| cell | current `main` image (`x86_64_v4`) | this branch's image (`x86_64_v3`) |
|---|---|---|
| TIM | `Illegal instruction (core dumped)` | **ctest 40/40** |
| FMS2 | `Illegal instruction (core dumped)` | **ctest 40/40** |

## ⚠️ Needs a follow-up action after merge

The consumer pulls the prebuilt `gcc-openmpi` tag, which is only published from
the default branch — so **merging this changes nothing until the image is
rebuilt**, and the two red checks on this PR stay red until then:

```bash
gh workflow run build-turbo-ci-container.yaml
```

Expect a full ~60 min build: the layer's cache key changed, so the buildcache
won't short-circuit it.

## Scope

Found while working #251, deliberately kept out of it — that work is about
running the pFUnit lane against MOM6's `dev/turbo-debug` and did not cause this.
Confirmed by dispatching the *unmodified* workflow against `main`
([run 31554615176](https://github.com/TURBO-ESM/turbo-stack/actions/runs/31554615176)):
both cells fail there identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
